### PR TITLE
Remove central config file as it's more trouble than it's worth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,3 @@ but a brief overview of the components:
 
 All components are built as docker images.
 Components which access the disk expect a shared directory mounted at `/mnt`.
-
-#### Configuration
-
-Configuration is built into the docker images, and set during build by specifying a
-YAML file `config.yaml` in the repository root directory.
-
-See the provided example file for documentation of options.

--- a/common/common.py
+++ b/common/common.py
@@ -5,37 +5,16 @@
 import datetime
 
 import dateutil.parser
-import yaml
 
 
-class Config(object):
-	def load(self,
-		run_start_time,
-	):
-		# PyYAML tries to...ugh...be clever, and parse timestamps if it can work out how.
-		# So we should only try to parse if it's not datetime already.
-		if not isinstance(run_start_time, datetime.datetime):
-			run_start_time = dateutil.parser.parse(run_start_time)
-		self.run_start_time = run_start_time
+def dt_to_bustime(start, dt):
+	"""Convert a datetime to bus time. Bus time is seconds since the given start point."""
+	return (dt - start).total_seconds()
 
 
-CONF = Config()
-
-
-def load_config(path="/etc/wubloader.yaml"):
-	with open(path) as f:
-		CONF.load(**yaml.safe_load(f))
-
-
-def dt_to_bustime(dt):
-	"""Convert a datetime to bus time. Bus time is seconds since the start of the run
-	as defined in the config file."""
-	return (dt - CONF.run_start_time).total_seconds()
-
-
-def bustime_to_dt(bustime):
+def bustime_to_dt(start, bustime):
 	"""Convert from bus time to a datetime"""
-	return CONF.run_start_time + datetime.timedelta(seconds=bustime)
+	return start + datetime.timedelta(seconds=bustime)
 
 
 def format_bustime(bustime, round="millisecond"):

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,0 @@
-
-# The timestamp of the beginning of the run.
-# This defines 00:00 bustime.
-# Should be in format YYYY-MM-DD hh:mm:ss.
-# Example: 2018-11-09 18:00:00
-run_start_time: 1970-01-01 00:00:00

--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -9,7 +9,4 @@ RUN pip install /tmp/common && rm -r /tmp/common
 COPY downloader /tmp/downloader
 RUN pip install /tmp/downloader && rm -r /tmp/downloader
 
-# Add config file last as it changes most
-COPY config.yaml /etc/wubloader.yaml
-
-CMD python2 -m downloader
+ENTRYPOINT python2 -m downloader --base-dir /mnt


### PR DESCRIPTION
Simpler and easier for testing to stick to configuration via CLI args.
We'll worry about deployment later.

This wasn't used anywhere yet anyway.