### PR TITLE
First pass at adding metrics to backfiller and downloader

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -15,6 +15,13 @@ import prometheus_client as prom
 import common
 
 
+segments_backfilled = prom.Counter(
+	'segments_backfilled',
+	"Number of segments successfully backfilled",
+	["remote", "stream", "variant", "hour"],
+)
+
+
 HOUR_FMT = '%Y-%m-%dT%H'
 TIMEOUT = 5 #default timeout for remote requests 
 
@@ -118,6 +125,7 @@ def get_remote_segment(base_dir, node, stream, variant, hour, missing_segment,
 		raise
 	logging.debug('Saving completed segment {} as {}'.format(temp_path, path))
 	common.rename(temp_path, path)
+	segments_backfilled.labels(remote=node, stream=stream, variant=variant, hour=hour).inc()
 
 
 def backfill(base_dir, stream, variants, hours=None, nodes=None):

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -234,6 +234,8 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 
 	variants = variants.split(',') if variants else []
 
+	common.PromLogCountsHandler.install()
+
 	logging.info('Starting backfilling {} with {} as variants to {}'.format(stream, ', '.join(variants), base_dir))
 
 	fill_start = datetime.datetime.now()

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -10,6 +10,7 @@ import time
 import uuid
 
 import requests
+import prometheus_client as prom
 
 import common
 
@@ -219,7 +220,7 @@ def backfill_node(base_dir, node, stream, variants, hours=None, segment_order='r
 	logging.info('Finished backfilling from {}'.format(node))
 
 							
-def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1):
+def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1, metrics_port=8002):
 	"""Prototype backfiller service.
 
 	Do a backfill of the last 3 hours from stream/variants from all nodes
@@ -235,6 +236,7 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 	variants = variants.split(',') if variants else []
 
 	common.PromLogCountsHandler.install()
+	prom.start_http_server(metrics_port)
 
 	logging.info('Starting backfilling {} with {} as variants to {}'.format(stream, ', '.join(variants), base_dir))
 

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -220,7 +220,7 @@ def backfill_node(base_dir, node, stream, variants, hours=None, segment_order='r
 	logging.info('Finished backfilling from {}'.format(node))
 
 							
-def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1, metrics_port=8002):
+def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1, metrics_port=8002, nodes=None):
 	"""Prototype backfiller service.
 
 	Do a backfill of the last 3 hours from stream/variants from all nodes
@@ -234,6 +234,8 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 	# stretch goal: use the backfiller to monitor the restreamer
 
 	variants = variants.split(',') if variants else []
+	if nodes is not None:
+		nodes = nodes.split(',') if nodes else []
 
 	common.PromLogCountsHandler.install()
 	prom.start_http_server(metrics_port)
@@ -244,9 +246,9 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 	full_fill_start = fill_start
 
 	
-	backfill(base_dir, stream, variants, 3)
+	backfill(base_dir, stream, variants, 3, nodes=nodes)
 
-	backfill(base_dir, stream, variants)
+	backfill(base_dir, stream, variants, nodes=nodes)
 	
 	# I'm sure there is a module that does this in a more robust way 
 	# but I understand this and it gives the behaviour I want
@@ -256,14 +258,14 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 
 		if now - full_fill_start > datetime.timedelta(minutes=full_fill_wait):
 
-			backfill(base_dir, stream, variants)
+			backfill(base_dir, stream, variants, nodes=nodes)
 
 			fill_start = now
 			full_fill_start = fill_start
 
 		elif now - fill_start > datetime.timedelta(minutes=fill_wait):
 
-			backfill(base_dir, stream, variants, 3)
+			backfill(base_dir, stream, variants, 3, nodes=nodes)
 
 			fill_start = now
 

--- a/common/common.py
+++ b/common/common.py
@@ -13,6 +13,7 @@ import sys
 from collections import namedtuple
 
 import dateutil.parser
+import prometheus_client as prom
 
 
 def dt_to_bustime(start, dt):
@@ -299,3 +300,16 @@ def encode_strings(o):
 	if isinstance(o, unicode):
 		return o.encode('utf-8')
 	return o
+
+
+log_count = prom.Counter("log_count", "Count of messages logged", ["level", "module", "function"])
+
+class PromLogCountsHandler(logging.Handler):
+	"""A logging handler that records a count of logs by level, module and function."""
+	def emit(self, record):
+		log_count.labels(record.levelname, record.module, record.funcName).inc()
+
+	@classmethod
+	def install(cls):
+		root_logger = logging.getLogger()
+		root_logger.addHandler(cls())

--- a/common/common.py
+++ b/common/common.py
@@ -5,6 +5,7 @@
 import base64
 import datetime
 import errno
+import functools
 import itertools
 import logging
 import os
@@ -14,6 +15,157 @@ from collections import namedtuple
 
 import dateutil.parser
 import prometheus_client as prom
+from monotonic import monotonic
+
+
+def timed(name=None,
+	buckets=[10.**x for x in range(-9, 5)], normalized_buckets=None,
+	normalize=None,
+	**labels
+):
+	"""Decorator that instruments wrapped function to record real, user and system time
+	as a prometheus histogram.
+
+	Metrics are recorded as NAME_latency, NAME_cputime{type=user} and NAME_cputime{type=system}
+	respectively. User and system time are process-wide (which means they'll be largely meaningless
+	if you're using gevent and the wrapped function blocks) and do not include subprocesses.
+
+	NAME defaults to the wrapped function's name.
+
+	Any labels passed in are included. Given label values may be callable, in which case
+	they are passed the input and result from the wrapped function and should return a label value.
+	Otherwise the given label value is used directly. All label values are automatically str()'d.
+
+	In addition, the "error" label is automatically included, and set to "" if no exception
+	occurs, or the name of the exception type if one does.
+
+	The normalize argument, if given, causes the creation of a second set of metrics
+	NAME_normalized_latency, etc. The normalize argument should be a callable which
+	takes the input and result of the wrapped function and returns a normalization factor.
+	All normalized metrics divide the observed times by this factor.
+	The intent is to allow a function which is expected to take longer given a larger input
+	to be timed on a per-input basis.
+	As a special case, when normalize returns 0 or None, normalized metrics are not updated.
+
+	The buckets kwarg is as per prometheus_client.Histogram. The default is a conservative
+	but sparse range covering nanoseconds to hours.
+	The normalized_buckets kwarg applies to the normalized metrics, and defaults to the same
+	as buckets.
+
+	All callables that take inputs and result take them as follows: The first arg is the result,
+	followed by *args and **kwargs as per the function's inputs.
+	If the wrapped function errored, result is None.
+	To simplify error handling in these functions, any errors are taken to mean None,
+	and None is interpreted as '' for label values.
+
+	Contrived Example:
+		@timed("scanner",
+			# constant label
+			foo="my example label",
+			# label dependent on input
+			all=lambda results, predicate, list, find_all=False: find_all,
+			# label dependent on output
+			found=lambda results, *a, **k: len(found) > 0,
+			# normalized on input
+			normalize=lambda results, predicate, list, **k: len(list),
+		)
+		def scanner(predicate, list, find_all=False):
+			results = []
+			for item in list:
+				if predicate(item):
+					results.append(item)
+					if not find_all:
+						break
+			return results
+	"""
+
+	if normalized_buckets is None:
+		normalized_buckets = buckets
+	# convert constant (non-callable) values into callables for consistency
+	labels = {
+		# there's a pyflakes bug here suggesting that v is undefined, but it isn't
+		k: v if callable(v) else (lambda *a, **k: v)
+		for k, v in labels.items()
+	}
+
+	def _timed(fn):
+		# can't safely assign to name inside closure, we use a new _name variable instead
+		_name = fn.__name__ if name is None else name
+
+		latency = prom.Histogram(
+			"{}_latency".format(_name),
+			"Wall clock time taken to execute {}".format(_name),
+			labels.keys() + ['error'],
+			buckets=buckets,
+		)
+		cputime = prom.Histogram(
+			"{}_cputime".format(_name),
+			"Process-wide consumed CPU time during execution of {}".format(_name),
+			labels.keys() + ['error', 'type'],
+			buckets=buckets,
+		)
+		if normalize:
+			normal_latency = prom.Histogram(
+				"{}_latency_normalized".format(_name),
+				"Wall clock time taken to execute {} per unit of work".format(_name),
+				labels.keys() + ['error'],
+				buckets=normalized_buckets,
+			)
+			normal_cputime = prom.Histogram(
+				"{}_cputime_normalized".format(_name),
+				"Process-wide consumed CPU time during execution of {} per unit of work".format(_name),
+				labels.keys() + ['error', 'type'],
+				buckets=normalized_buckets,
+			)
+
+		@functools.wraps(fn)
+		def wrapper(*args, **kwargs):
+			start_monotonic = monotonic()
+			start_user, start_sys, _, _, _ = os.times()
+
+			try:
+				ret = fn(*args, **kwargs)
+			except Exception:
+				ret = None
+				error_type, error, tb = sys.exc_info()
+			else:
+				error = None
+
+			end_monotonic = monotonic()
+			end_user, end_sys, _, _, _ = os.times()
+			wall_time = end_monotonic - start_monotonic
+			user_time = end_user - start_user
+			sys_time = end_sys - start_sys
+
+			label_values = {}
+			for k, v in labels.items():
+				try:
+					value = v(ret, *args, **kwargs)
+				except Exception:
+					value = None
+				label_values[k] = '' if value is None else str(value)
+			label_values.update(error='' if error is None else type(error).__name__)
+
+			latency.labels(**label_values).observe(wall_time)
+			cputime.labels(type='user', **label_values).observe(user_time)
+			cputime.labels(type='system', **label_values).observe(sys_time)
+			if normalize:
+				try:
+					factor = normalize(ret, *args, **kwargs)
+				except Exception:
+					factor = None
+				if factor is not None and factor > 0:
+					normal_latency.labels(**label_values).observe(wall_time / factor)
+					normal_cputime.labels(type='user', **label_values).observe(user_time / factor)
+					normal_cputime.labels(type='system', **label_values).observe(sys_time / factor)
+
+			if error is None:
+				return ret
+			raise error_type, error, tb # re-raise error with original traceback
+
+		return wrapper
+
+	return _timed
 
 
 def dt_to_bustime(start, dt):
@@ -116,6 +268,11 @@ def parse_segment_path(path):
 		raise ValueError, ValueError("Bad path {!r}: {}".format(path, e)), tb
 
 
+@timed(
+	hours_path=lambda ret, hours_path, start, end: hours_path,
+	has_holes=lambda ret, hours_path, start, end: None in ret,
+	normalize=lambda ret, hours_path, start, end: len([x for x in ret if x is not None]),
+)
 def get_best_segments(hours_path, start, end):
 	"""Return a list of the best sequence of non-overlapping segments
 	we have for a given time range. Hours path should be the directory containing hour directories.

--- a/common/setup.py
+++ b/common/setup.py
@@ -5,7 +5,7 @@ setup(
 	version = "0.0.0",
 	py_modules = ["common"],
 	install_requires = [
+		"prometheus-client",
 		"python-dateutil",
-		"PyYAML<4.0.0",
 	],
 )

--- a/common/setup.py
+++ b/common/setup.py
@@ -5,6 +5,7 @@ setup(
 	version = "0.0.0",
 	py_modules = ["common"],
 	install_requires = [
+		"monotonic",
 		"prometheus-client",
 		"python-dateutil",
 	],

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -21,8 +21,13 @@
   // On OSX you need to change this to /private/var/lib/wubloader
   segments_path:: "/var/lib/wubloader/",
 
-  // The host's port to expose the restreamer on.
-  restreamer_port:: 8080,
+  // The host's port to expose each service on.
+  // Only the restreamer needs to be externally accessible - the others are just for monitoring.
+  ports:: {
+    restreamer: 8080,
+    downloader: 8001,
+    backfiller: 8002,
+  },
 
 
   // Now for the actual docker-compose config
@@ -43,6 +48,9 @@
       volumes: ["%s:/mnt" % $.segments_path],
       // If the application crashes, restart it.
       restart: "on-failure",
+      // Expose on the configured host port by mapping that port to the default
+      // port for downloader, which is 8001.
+      ports: ["%s:8001" % $.ports.downloader]
     },
 
     restreamer: {
@@ -53,7 +61,7 @@
       restart: "on-failure",
       // Expose on the configured host port by mapping that port to the default
       // port for restreamer, which is 8000.
-      ports: ["%s:8000" % $.restreamer_port],
+      ports: ["%s:8000" % $.ports.restreamer],
     },
 
     backfiller: {
@@ -67,6 +75,9 @@
       volumes: ["%s:/mnt" % $.segments_path],
       // If the application crashes, restart it.
       restart: "on-failure",
+      // Expose on the configured host port by mapping that port to the default
+      // port for backfiller, which is 8002.
+      ports: ["%s:8002" % $.ports.backfiller]
     },
 
 

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -29,6 +29,10 @@
     backfiller: 8002,
   },
 
+  // Other nodes to backfill from. You should not include the local node.
+  peers:: [
+    "http://wubloader.codegunner.com/"
+  ],  
 
   // Now for the actual docker-compose config
 
@@ -70,6 +74,7 @@
       command: [
         "--stream", $.channel,
         "-v", std.join(",", $.qualities),
+        "--nodes", std.join(",", $.peers),
       ],
       // Mount the segments directory at /mnt
       volumes: ["%s:/mnt" % $.segments_path],

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -14,8 +14,8 @@
   // Twitch channel to capture
   channel:: "desertbus",
 
-  // Stream qualities to capture in addition to source.
-  qualities:: ["480p"],
+  // Stream qualities to capture
+  qualities:: ["source", "480p"],
 
   // Local path to save segments to. Full path must already exist. Cannot contain ':'.
   // On OSX you need to change this to /private/var/lib/wubloader

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -494,6 +494,7 @@ def main(channel, base_dir=".", qualities=""):
 	qualities = qualities.split(",") if qualities else []
 	manager = StreamsManager(channel, base_dir, qualities)
 	gevent.signal(signal.SIGTERM, manager.stop) # shut down on sigterm
+	common.PromLogCountsHandler.install()
 	logging.info("Starting up")
 	manager.run()
 	logging.info("Gracefully stopped")

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -100,7 +100,7 @@ class StreamsManager(object):
 		self.channel = channel
 		self.logger = logging.getLogger("StreamsManager({})".format(channel))
 		self.base_dir = base_dir
-		self.stream_workers = {name: [] for name in qualities + ["source"]} # {stream name: [workers]}
+		self.stream_workers = {name: [] for name in qualities} # {stream name: [workers]}
 		self.latest_urls = {} # {stream name: (fetch time, url)}
 		self.latest_urls_changed = gevent.event.Event() # set when latest_urls changes
 		self.refresh_needed = gevent.event.Event() # set to tell main loop to refresh now
@@ -500,7 +500,7 @@ class SegmentGetter(object):
 			segments_downloaded.labels(partial="False", stream=self.channel, variant=self.stream).inc()
 
 
-def main(channel, base_dir=".", qualities="", metrics_port=8001):
+def main(channel, base_dir=".", qualities="source", metrics_port=8001):
 	qualities = qualities.split(",") if qualities else []
 	manager = StreamsManager(channel, base_dir, qualities)
 	gevent.signal(signal.SIGTERM, manager.stop) # shut down on sigterm

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 import dateutil.parser
 import gevent
 import gevent.event
+import prometheus_client as prom
 import requests
 from monotonic import monotonic
 
@@ -490,11 +491,12 @@ class SegmentGetter(object):
 			common.rename(temp_path, full_path)
 
 
-def main(channel, base_dir=".", qualities=""):
+def main(channel, base_dir=".", qualities="", metrics_port=8001):
 	qualities = qualities.split(",") if qualities else []
 	manager = StreamsManager(channel, base_dir, qualities)
 	gevent.signal(signal.SIGTERM, manager.stop) # shut down on sigterm
 	common.PromLogCountsHandler.install()
+	prom.start_http_server(metrics_port)
 	logging.info("Starting up")
 	manager.run()
 	logging.info("Gracefully stopped")

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -16,7 +16,7 @@ from flask import Flask, url_for, request, abort, Response
 from gevent import subprocess
 from gevent.pywsgi import WSGIServer
 
-from common import get_best_segments
+from common import get_best_segments, PromLogCountsHandler
 
 import generate_hls
 from stats import stats, after_request
@@ -396,6 +396,8 @@ def main(host='0.0.0.0', port=8000, base_dir='.'):
 		logging.info("Shutting down")
 		server.stop()
 	gevent.signal(signal.SIGTERM, stop)
+
+	PromLogCountsHandler.install()
 
 	logging.info("Starting up")
 	server.serve_forever()


### PR DESCRIPTION
Didn't end up adding much specific metrics that are actually helpful,
instead I put in some easy generic stuff:

* `get_best_segments` will report time taken as well as errors,
  and in doing so I made a general timing helper that will make timing further things easy.

* We get a count of log messages by level, module, and function name.
  This will give us a reasonable overview of events going on even without
  more specific metrics.