### PR TITLE
downloader: A few fixes to error handling logic

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -321,6 +321,7 @@ class StreamWorker(object):
 
 			# We successfully got the playlist at least once
 			first = False
+			self.manager.mark_working(self)
 
 			# Start any new segment getters
 			date = None # tracks date in case some segment doesn't include it


### PR DESCRIPTION
see individual commits for full details, but tl;dr:

* once a url is old enough, twitch switches from 403-ing to 404-ing. we should give up on that.
* we were never marking new workers as working, so old workers persisted forever