### PR TITLE
Add gevent.backdoor as an optional arg to all services

### DIFF
--- a/backfiller/Dockerfile
+++ b/backfiller/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 # dependencies needed for compiling c extensions
-RUN apk --update add py2-pip gcc python-dev musl-dev
+# also busybox-extras for telnet for easier use of backdoor
+RUN apk --update add py2-pip gcc python-dev musl-dev busybox-extras
 
 # Install common lib first as it changes less
 COPY common /tmp/common

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -9,8 +9,9 @@ import random
 import time
 import uuid
 
-import requests
+import gevent.backdoor
 import prometheus_client as prom
+import requests
 
 import common
 
@@ -228,7 +229,7 @@ def backfill_node(base_dir, node, stream, variants, hours=None, segment_order='r
 	logging.info('Finished backfilling from {}'.format(node))
 
 							
-def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1, metrics_port=8002, nodes=None):
+def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, sleep_time=1, metrics_port=8002, nodes=None, backdoor_port=0):
 	"""Prototype backfiller service.
 
 	Do a backfill of the last 3 hours from stream/variants from all nodes
@@ -247,6 +248,9 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 
 	common.PromLogCountsHandler.install()
 	prom.start_http_server(metrics_port)
+
+	if backdoor_port:
+		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()
 
 	logging.info('Starting backfilling {} with {} as variants to {}'.format(stream, ', '.join(variants), base_dir))
 

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -29,6 +29,10 @@
     backfiller: 8002,
   },
 
+  // The local port within each container to bind the backdoor server on.
+  // You can exec into the container and telnet to this port to get a python shell.
+  backdoor_port:: 1234,
+
   // Other nodes to backfill from. You should not include the local node.
   peers:: [
     "http://wubloader.codegunner.com/"
@@ -47,6 +51,7 @@
       command: [
         $.channel,
         "--qualities", std.join(",", $.qualities),
+        "--backdoor-port", std.toString($.backdoor_port),
       ],
       // Mount the segments directory at /mnt
       volumes: ["%s:/mnt" % $.segments_path],
@@ -66,6 +71,9 @@
       // Expose on the configured host port by mapping that port to the default
       // port for restreamer, which is 8000.
       ports: ["%s:8000" % $.ports.restreamer],
+      command: [
+        "--backdoor-port", std.toString($.backdoor_port),
+      ],
     },
 
     backfiller: {
@@ -75,6 +83,7 @@
         "--stream", $.channel,
         "-v", std.join(",", $.qualities),
         "--nodes", std.join(",", $.peers),
+        "--backdoor-port", std.toString($.backdoor_port),
       ],
       // Mount the segments directory at /mnt
       volumes: ["%s:/mnt" % $.segments_path],

--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 # dependencies needed for compiling c extensions
-RUN apk --update add py2-pip gcc python-dev musl-dev
+# also busybox-extras for telnet for easier use of backdoor
+RUN apk --update add py2-pip gcc python-dev musl-dev busybox-extras
 
 # Install common lib first as it changes less
 COPY common /tmp/common

--- a/restreamer/Dockerfile
+++ b/restreamer/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 # dependencies needed for compiling c extensions, plus ffmpeg for cutting
-RUN apk --update add py2-pip gcc python-dev musl-dev ffmpeg
+# also busybox-extras for telnet for easier use of backdoor
+RUN apk --update add py2-pip gcc python-dev musl-dev ffmpeg busybox-extras
 
 # Install common lib first as it changes less
 COPY common /tmp/common

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -11,6 +11,7 @@ from contextlib import closing
 
 import dateutil.parser
 import gevent
+import gevent.backdoor
 import prometheus_client as prom
 from flask import Flask, url_for, request, abort, Response
 from gevent import subprocess
@@ -388,7 +389,7 @@ def cut_experimental(segments, cut_start, cut_end):
 
 
 
-def main(host='0.0.0.0', port=8000, base_dir='.'):
+def main(host='0.0.0.0', port=8000, base_dir='.', backdoor_port=0):
 	app.static_folder = base_dir
 	server = WSGIServer((host, port), cors(app))
 
@@ -398,6 +399,9 @@ def main(host='0.0.0.0', port=8000, base_dir='.'):
 	gevent.signal(signal.SIGTERM, stop)
 
 	PromLogCountsHandler.install()
+
+	if backdoor_port:
+		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()
 
 	logging.info("Starting up")
 	server.serve_forever()


### PR DESCRIPTION
Backdoor allows the operator to telnet into the given port, and get a python shell
running inside the process, from which you can debug, modify state (eg. set the log level),
or whatever. This is extremely useful for debugging weird states that you encounter randomly
but can't easily reproduce, without restarting the process and needing to wait until it happens again.