### PR TITLE
Performance improvements for get_best_segments

### DIFF
--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -11,8 +11,6 @@ import os
 import sys
 from collections import namedtuple
 
-import dateutil.parser
-
 from .stats import timed
 
 
@@ -58,7 +56,7 @@ def parse_segment_path(path):
 			path = path,
 			stream = stream,
 			variant = variant,
-			start = dateutil.parser.parse("{}:{}".format(hour, time)),
+			start = datetime.datetime.strptime("{}:{}".format(hour, time), "%Y-%m-%dT%H:%M:%S.%f"),
 			duration = datetime.timedelta(seconds=float(duration)),
 			is_partial = type == "partial",
 			hash = unpadded_b64_decode(hash),

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -11,6 +11,8 @@ import os
 import sys
 from collections import namedtuple
 
+import gevent
+
 from .stats import timed
 
 
@@ -109,6 +111,11 @@ def get_best_segments(hours_path, start, end):
 	result = []
 
 	for hour in hour_paths_for_range(hours_path, start, end):
+		# Especially when processing multiple hours, this routine can take a signifigant amount
+		# of time with no blocking. To ensure other stuff is still completed in a timely fashion,
+		# we yield to let other things run.
+		gevent.idle()
+
 		# best_segments_by_start will give us the best available segment for each unique start time
 		for segment in best_segments_by_start(hour):
 

--- a/common/setup.py
+++ b/common/setup.py
@@ -8,6 +8,5 @@ setup(
 		"gevent",
 		"monotonic",
 		"prometheus-client",
-		"python-dateutil",
 	],
 )


### PR DESCRIPTION
Approx 80% of our time for large get_best_segments calls were in date parsing.
This uses strptime instead, which is much faster.

We also ensure we let other things run while we're processing, to prevent stalling
all other work / causing the service to go unresponsive.

This PR is based on #30 and will need to be rebased once that's merged