### PR TITLE
stats: Send profiling information to grafana to generate flamegraphs

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -247,6 +247,7 @@ def main(base_dir='.', stream='', variants='', fill_wait=5, full_fill_wait=180, 
 		nodes = nodes.split(',') if nodes else []
 
 	common.PromLogCountsHandler.install()
+	common.install_stacksampler()
 	prom.start_http_server(metrics_port)
 
 	if backdoor_port:

--- a/common/common/__init__.py
+++ b/common/common/__init__.py
@@ -8,7 +8,7 @@ import os
 import random
 
 from .segments import get_best_segments, parse_segment_path, SegmentInfo
-from .stats import timed, PromLogCountsHandler
+from .stats import timed, PromLogCountsHandler, install_stacksampler
 
 
 def dt_to_bustime(start, dt):

--- a/common/setup.py
+++ b/common/setup.py
@@ -5,6 +5,7 @@ setup(
 	version = "0.0.0",
 	packages = find_packages(),
 	install_requires = [
+		"gevent",
 		"monotonic",
 		"prometheus-client",
 		"python-dateutil",

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -527,6 +527,7 @@ def main(channel, base_dir=".", qualities="source", metrics_port=8001, backdoor_
 	manager = StreamsManager(channel, base_dir, qualities)
 	gevent.signal(signal.SIGTERM, manager.stop) # shut down on sigterm
 	common.PromLogCountsHandler.install()
+	common.install_stacksampler()
 	prom.start_http_server(metrics_port)
 	if backdoor_port:
 		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()

--- a/generate-flamegraph
+++ b/generate-flamegraph
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eu
+
+USAGE="USAGE: $0 PROM_URL SERVICE DURATION [TIME [LABELS]] > flamegraph.svg
+Generate a flamegraph for the given service using data from the given prometheus server.
+Uses DURATION amount of data (in prometheus timespec format, eg '15m'), ending at TIME,
+which may be unix time or RFC3339, defaults to now.
+Labels is optional extra prometheus labels to match on, in promql format,
+eg. 'foo=\"bar\",baz=\"123\"'
+Note that in the resulting flamegraph, the 'samples' value is actually showing milliseconds
+of cpu time over the given duration."
+
+if [ "$#" -lt 3 ]; then
+	echo "$USAGE" >&2
+	exit 1
+fi
+
+PROM=$1
+SERVICE=$2
+DURATION=$3
+TIME=${4:-now}
+LABELS=${5:-}
+
+if [ "$TIME" == "now" ]; then
+	TIME=$(date +%s)
+fi
+
+if [ -n "$LABELS" ]; then
+	LABELS="job=\"$SERVICE\""
+else
+	LABELS="job=\"$SERVICE\",$LABELS"
+fi
+
+docker build -t wubloader-flamegraph:latest . -f - 1>&2 <<EOF
+FROM alpine:3.7
+RUN apk --update add curl jq perl
+RUN curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl -o /flamegraph.pl
+EOF
+
+docker run -i --rm -e PROM= wubloader-flamegraph:latest /bin/sh -c "
+curl -G '$PROM/api/v1/query' --data-urlencode 'time=$TIME' --data-urlencode 'query=sum(increase(flamegraph_total{$LABELS}[$DURATION])) by (stack) * 1000 > 0' |
+jq -r '.data.result[]|\"\\(.metric.stack) \\(.value[1])\"' |
+perl /flamegraph.pl
+"

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -17,7 +17,7 @@ from flask import Flask, url_for, request, abort, Response
 from gevent import subprocess
 from gevent.pywsgi import WSGIServer
 
-from common import get_best_segments, PromLogCountsHandler
+from common import get_best_segments, PromLogCountsHandler, install_stacksampler
 
 import generate_hls
 from stats import stats, after_request
@@ -421,6 +421,7 @@ def main(host='0.0.0.0', port=8000, base_dir='.', backdoor_port=0):
 	gevent.signal(signal.SIGTERM, stop)
 
 	PromLogCountsHandler.install()
+	install_stacksampler()
 
 	if backdoor_port:
 		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()


### PR DESCRIPTION
In this PR we use a technique called stack-sampling to estimate CPU usage by function.

We use a kernel mechanism to deliver a SIGVTALRM signal to the process every time
we spend 5ms actually scheduled onto a CPU and doing work (not just waiting for something to
happen, and not counting time spent in the kernel doing work on our behalf like reading
from disk - this only counts actual CPU time used in the process's code).

Upon receiving the signal, we record the current call stack using a prometheus counter.

This allows us to later retrieve a list of unique call stacks we observed,
along with how often we saw it.
Statistically, the longer amount of time we spend in a function, the more likely it is
to be seen when we get a signal. By looking at how often we see a function, we can estimate
the amount of time we spend in it.

This kind of data can be rendered into a flamegraph (http://www.brendangregg.com/flamegraphs.html),
which is very useful for diagnosing performance issues.

We provide a script generate-flamegraph for querying prometheus to generate these.

There were some complications to this approach - see the commits about deadlocks.

This PR is based on #30 and will need to be rebased once that's merged.