### PR TITLE
downloader: Changes to mitigate resource contention feedback loop

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -387,7 +387,7 @@ class SegmentGetter(object):
 	FETCH_RETRY = 2
 	# Headers timeout is timeout before getting the start of a response,
 	# full timeout is for the entire download and stream to disk.
-	FETCH_HEADERS_TIMEOUTS = 5, 30
+	FETCH_HEADERS_TIMEOUTS = 5, 60
 	FETCH_FULL_TIMEOUTS = 15, 240
 
 	def __init__(self, parent_logger, session, base_dir, channel, stream, segment, date):


### PR DESCRIPTION
In resource contention scenarios, all calls can start failing due to not
being able to read the response in a timely manner. This means
SegmentGetters never stop retrying, leading to further contention and a
feedback loop. In this PR we try to mitigate this scenario.

One easy way to do this is to increase the time we have to finish fetching
headers.

We also attempt to put at least some cap on this scenario by
giving up if an amount of time has elapsed to the point that we know our
URL couldn't be valid anymore. Since we don't actually know how long
segment URLs are valid, we are very conservative about this time, for now
setting it to 20min.