### PR TITLE
Ignore segments that are marked as ads

### DIFF
--- a/downloader/downloader/twitch.py
+++ b/downloader/downloader/twitch.py
@@ -38,6 +38,9 @@ def get_master_playlist(channel, session=requests):
 			# Also observed in the wild but not used in streamlink:
 			# "playlist_include_framerate": "true"
 			# "reassignments_supported": "true"
+			# It's reported that setting this may affect whether you get ads, but this is
+			# in flux. Better to just blend in with the crowd for now.
+			# "platform": "_"
 		},
 	)
 	resp.raise_for_status() # getting master playlist


### PR DESCRIPTION
* Checks for the SCTE35-OUT/SCTE35-IN marks in the HLS stream that indicate an ad start/end
* Ignores those segments completely
* Doesn't mark the StreamWorker as up until it sees the first non-ad segment

Some other operational notes:
* The main risk this adds is that re-connecting / refreshing master playlist takes longer.
  If all downloaders are doing this at the same time (ie. because the stream only just came up,
  or during a deployment rollout), all downloaders might be waiting for ads to finish and
  you'll miss segments.
* We should run more downloaders to compensate. This also increases the chance at least one of
  them won't get any ads, so we get everything right from stream-up.
* The other mitigation we can do is have geographically diverse downloaders. This decreases the risk
  that they all get served an ad, and at least at time of writing it seems that no in-stream ads
  are served outside of these regions:

> US, Canada, Germany, France, Sweden, Belgium, Poland, Norway, Finland, Denmark, Netherlands, Italy, Spain, Switzerland, Austria, Portugal, UK, Australia, New Zealand