### PR TITLE
Audit and fix all usage of dateutil

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -11,12 +11,12 @@ import urlparse
 import uuid
 
 import argh
-import dateutil.parser
 import gevent.backdoor
 import prometheus_client as prom
 import requests
 
 import common
+import common.dateutil
 
 
 segments_backfilled = prom.Counter(
@@ -385,7 +385,7 @@ def main(streams, base_dir='.', variants='source', metrics_port=8002,
 			start = float(start)
 			logging.info('Backfilling last {} hours'.format(start))
 		except ValueError:
-			start = dateutil.parser.parse(start)
+			start = common.dateutil.parse(start)
 			logging.info('Backfilling since {}'.format(start)) 
 
 	common.PromLogCountsHandler.install()

--- a/common/common/dateutil.py
+++ b/common/common/dateutil.py
@@ -1,0 +1,23 @@
+
+
+"""Wrapper code around dateutil to use it more sanely"""
+
+
+# required so we are able to import dateutil despite this module also being called dateutil
+from __future__ import absolute_import
+
+import dateutil.parser
+import dateutil.tz
+
+
+def parse(timestamp):
+	"""Parse given timestamp, convert to UTC, and return naive UTC datetime"""
+	dt = dateutil.parser.parse(timestamp)
+	if dt.tzinfo is not None:
+		dt = dt.astimezone(dateutil.tz.tzutc()).replace(tzinfo=None)
+	return dt
+
+
+def parse_utc_only(timestamp):
+	"""Parse given timestamp, but assume it's already in UTC and ignore other timezone info"""
+	return dateutil.parser.parse(timestamp, ignoretz=True)

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -11,7 +11,6 @@ from base64 import b64encode
 from contextlib import contextmanager
 
 import argh
-import dateutil.parser
 import gevent
 import gevent.backdoor
 import gevent.event
@@ -21,6 +20,7 @@ from monotonic import monotonic
 
 import twitch
 import common
+import common.dateutil
 
 
 segments_downloaded = prom.Counter(
@@ -344,7 +344,7 @@ class StreamWorker(object):
 				self.manager.mark_working(self)
 
 				if segment.date:
-					date = dateutil.parser.parse(segment.date)
+					date = common.dateutil.parse(segment.date)
 				if segment.uri not in self.getters:
 					if date is None:
 						raise ValueError("Cannot determine date of segment")


### PR DESCRIPTION
We wrap direct dateutil calls to handle two distinct cases:

* `common.dateutil.parse()`: We want to handle arbitrary timestamps including tz info,
then convert them to UTC.

This is used in HLS parsing, and for command line input for backfiller

* `common.dateutil.parse_utc_only()`: We want to only handle UTC timestamps,
but datetime.strptime isn't flexible enough (eg. can't handle missing fractional component).

This is used for restreamer request params.