### PR TITLE
Chrusher/backfiller/refactor

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -91,7 +91,7 @@ def get_remote_segment(base_dir, node, channel, quality, hour, missing_segment,
 	try:
 		logging.debug('Fetching segment {} from {}'.format(path, node))
 		uri = '{}/segments/{}/{}/{}/{}'.format(node, channel, quality, hour, missing_segment)
-		resp = requests.get(uri, channel=True, timeout=timeout)
+		resp = requests.get(uri, stream=True, timeout=timeout)
 
 		resp.raise_for_status()
 

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -22,8 +22,8 @@ from common import database
 
 segments_backfilled = prom.Counter(
 	'segments_backfilled',
-	"Number of segments successfully backfilled",
-	["remote", "stream", "variant", "hour"],
+	'Number of segments successfully backfilled',
+	['remote', 'channel', 'quality', 'hour'],
 )
 
 

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -28,7 +28,7 @@ def unpadded_b64_decode(s):
 
 class SegmentInfo(
 	namedtuple('SegmentInfoBase', [
-		'path', 'stream', 'variant', 'start', 'duration', 'type', 'hash'
+		'path', 'channel', 'quality', 'start', 'duration', 'type', 'hash'
 	])
 ):
 	"""Info parsed from a segment path, including original path.
@@ -48,7 +48,7 @@ def parse_segment_path(path):
 	# left-pad parts with None up to 4 parts
 	parts = [None] * (4 - len(parts)) + parts
 	# pull info out of path parts
-	stream, variant, hour, filename = parts[-4:]
+	channel, quality, hour, filename = parts[-4:]
 	# split filename, which should be TIME-DURATION-TYPE-HASH.ts
 	try:
 		if not filename.endswith('.ts'):
@@ -63,8 +63,8 @@ def parse_segment_path(path):
 		hash = None if type == 'temp' else unpadded_b64_decode(hash)
 		return SegmentInfo(
 			path = path,
-			stream = stream,
-			variant = variant,
+			channel = channel,
+			quality = quality,
 			start = datetime.datetime.strptime("{}:{}".format(hour, time), "%Y-%m-%dT%H:%M:%S.%f"),
 			duration = datetime.timedelta(seconds=float(duration)),
 			type = type,

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -171,7 +171,7 @@
 
     [if $.enabled.thrimshim then "thrimshim"]: {
       image: "quay.io/ekimekim/wubloader-thrimshim:%s" % $.image_tag,
-      // Args for the thrimshim: set channel and qualities
+      // Args for the thrimshim: database connection string 
       command: [
         "--backdoor-port", std.toString($.backdoor_port),
         $.db_connect,

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -134,7 +134,7 @@
       command: [
         $.channel,
         "--base-dir", "/mnt",
-        "--variants", std.join(",", $.qualities),
+        "--qualities", std.join(",", $.qualities),
         "--static-nodes", std.join(",", $.peers),
         "--backdoor-port", std.toString($.backdoor_port),
       ],

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -26,13 +26,13 @@ import common.dateutil
 segments_downloaded = prom.Counter(
 	"segments_downloaded",
 	"Number of segments either partially or fully downloaded",
-	["partial", "stream", "variant"],
+	["partial", "channel", "quality"],
 )
 
 latest_segment = prom.Gauge(
 	"latest_segment",
 	"Timestamp of the time of the newest segment fully downloaded",
-	["stream", "variant"],
+	["channel", "quality"],
 )
 
 
@@ -541,16 +541,16 @@ class SegmentGetter(object):
 				partial_path = self.make_path("partial", hash)
 				self.logger.warning("Saving partial segment {} as {}".format(temp_path, partial_path))
 				common.rename(temp_path, partial_path)
-				segments_downloaded.labels(partial="True", stream=self.channel, variant=self.stream).inc()
+				segments_downloaded.labels(partial="True", channel=self.channel, quality=self.stream).inc()
 			raise ex_type, ex, tb
 		else:
 			full_path = self.make_path("full", hash)
 			self.logger.debug("Saving completed segment {} as {}".format(temp_path, full_path))
 			common.rename(temp_path, full_path)
-			segments_downloaded.labels(partial="False", stream=self.channel, variant=self.stream).inc()
+			segments_downloaded.labels(partial="False", channel=self.channel, quality=self.stream).inc()
 			# Prom doesn't provide a way to compare value to gauge's existing value,
 			# we need to reach into internals
-			stat = latest_segment.labels(stream=self.channel, variant=self.stream)
+			stat = latest_segment.labels(channel=self.channel, quality=self.stream)
 			timestamp = (self.date - datetime.datetime(1970, 1, 1)).total_seconds()
 			stat.set(max(stat._value.get(), timestamp)) # NOTE: not thread-safe but is gevent-safe
 

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -283,7 +283,7 @@ class StreamWorker(object):
 		self.session = requests.Session()
 
 	def __repr__(self):
-		return "<{} at 0x{:x} for stream {!r}>".format(type(self).__name__, id(self), self.stream)
+		return "<{} at 0x{:x} for stream {!r}>".format(type(self).__name__, id(self), self.quality)
 	__str__ = __repr__
 
 	def age(self):
@@ -307,7 +307,7 @@ class StreamWorker(object):
 			for getter in self.getters.values():
 				getter.done.wait()
 			self.done.set()
-			self.manager.stream_workers[self.stream].remove(self)
+			self.manager.stream_workers[self.quality].remove(self)
 
 	def trigger_new_worker(self):
 		self.manager.trigger_new_worker(self)

--- a/monitoring/dashboards/overview.jsonnet
+++ b/monitoring/dashboards/overview.jsonnet
@@ -119,10 +119,10 @@ grafana.dashboard({
             name: "Segments downloaded",
             axis: {min: 0, label: "segments / sec"},
             expressions: {
-              "{{stream}}({{variant}}) live capture":
-                'sum(rate(segments_downloaded_total[2m])) by (stream, variant)',
-              "{{stream}}({{variant}}) backfilled":
-                'sum(rate(segments_backfilled_total[2m])) by (stream, variant)',
+              "{{channel}}({{quality}}) live capture":
+                'sum(rate(segments_downloaded_total[2m])) by (channel, quality)',
+              "{{channel}}({{quality}}) backfilled":
+                'sum(rate(segments_backfilled_total[2m])) by (channel, quality)',
             },
           },
           {
@@ -150,8 +150,8 @@ grafana.dashboard({
           name: "Segments downloaded by node",
           axis: {min: 0, label: "segments / sec"},
           expressions: {
-            "{{instance}} {{stream}}({{variant}})":
-              'sum(rate(segments_downloaded_total[2m])) by (instance, stream, variant)',
+            "{{instance}} {{channel}}({{quality}})":
+              'sum(rate(segments_downloaded_total[2m])) by (instance, channel, quality)',
           },
         },
         {
@@ -159,8 +159,8 @@ grafana.dashboard({
           tooltip: "Time between the latest downloaded segment's timestamp and current time",
           axis: {min: 0, format: grafana.formats.time},
           expressions: {
-            "{{instance}} {{stream}}({{variant}})":
-              'time() - max(latest_segment) by (instance, stream, variant)',
+            "{{instance}} {{channel}}({{quality}})":
+              'time() - max(latest_segment) by (instance, channel, quality)',
           },
         },
       ],

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -160,7 +160,7 @@ def time_range_for_quality(channel, quality):
 def generate_master_playlist(channel):
 	"""Returns a HLS master playlist for the given channel.
 	Takes optional params:
-		start, end: The time to begin and end the channel at.
+		start, end: The time to begin and end the stream at.
 			See generate_media_playlist for details.
 	"""
 	start = common.dateutil.parse_utc_only(request.args['start']) if 'start' in request.args else None
@@ -190,7 +190,7 @@ def generate_master_playlist(channel):
 def generate_media_playlist(channel, quality):
 	"""Returns a HLS media playlist for the given channel and quality.
 	Takes optional params:
-		start, end: The time to begin and end the channel at.
+		start, end: The time to begin and end the stream at.
 			Must be in ISO 8601 format (ie. yyyy-mm-ddTHH:MM:SS) and UTC.
 			If not given, effectively means "infinity", ie. no start means
 			any time ago, no end means any time in the future.


### PR DESCRIPTION
Refactor the `backfiller`, `downloader`, `restreamer` and `common` to use _channel_ and _quality_ (as in the database) instead of _stream_ and _variant_. I've checked these changes using `pyflakes` and by briefly running `backfiller`, `downloader` and `restreamer` but I have not tested the other wubloader components against these changes.