### PR TITLE
Gunner/thrimbletrimmer improvements

### DIFF
--- a/thrimbletrimmer/dashboard.html
+++ b/thrimbletrimmer/dashboard.html
@@ -231,9 +231,9 @@
                     <td>${event.description}</td>
                     <td>${event.state}</td>
                     <td><a href="/thrimbletrimmer?id=${event.id}">Edit</a></td>
-                    <td>${event.video_link ? "<a href='"+event.video_link+"'>"+event.video_link+"</a>":""}</td>
-                    <td>${event.edit_time}</td>
-                    <td>${event.upload_time}</td>
+                    <td>${event.video_link ? "<a href='"+event.video_link+"'>Link</a>":""}</td>
+                    <td>${event.edit_time.substring(0,19)}</td>
+                    <td>${event.upload_time.substring(0,19)}</td>
                 `;
                 document.getElementById('QueueTable').appendChild(row);
             });

--- a/thrimbletrimmer/dashboard.html
+++ b/thrimbletrimmer/dashboard.html
@@ -135,6 +135,8 @@
                     <th>State</th>
                     <th>Edit</th>
                     <th>Link</th>
+                    <th>Edit Time</th>
+                    <th>Upload Time</th>
                 </tr>
             </table>
         </div>
@@ -218,6 +220,9 @@
 
         function populateTable (events) {
             events.forEach(event => {
+                if(!event.description) { //If a row doesn't have a description, it's probably orphaned from the spreadsheet, and does not need to be displayed.
+                    return;
+                }
                 let row = document.createElement("TR");
                 row.innerHTML = `
                     <td>${event.event_start}</td>
@@ -227,6 +232,8 @@
                     <td>${event.state}</td>
                     <td><a href="/thrimbletrimmer?id=${event.id}">Edit</a></td>
                     <td>${event.video_link ? "<a href='"+event.video_link+"'>"+event.video_link+"</a>":""}</td>
+                    <td>${event.edit_time}</td>
+                    <td>${event.upload_time}</td>
                 `;
                 document.getElementById('QueueTable').appendChild(row);
             });

--- a/thrimbletrimmer/dashboard.html
+++ b/thrimbletrimmer/dashboard.html
@@ -232,8 +232,8 @@
                     <td>${event.state}</td>
                     <td><a href="/thrimbletrimmer?id=${event.id}">Edit</a></td>
                     <td>${event.video_link ? "<a href='"+event.video_link+"'>Link</a>":""}</td>
-                    <td>${event.edit_time.substring(0,19)}</td>
-                    <td>${event.upload_time.substring(0,19)}</td>
+                    <td>${event.edit_time ? event.edit_time.substring(0,19):""}</td>
+                    <td>${event.upload_time ? event.upload_time.substring(0,19):""}</td>
                 `;
                 document.getElementById('QueueTable').appendChild(row);
             });

--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -86,7 +86,8 @@
                 Description:<br/>
                 <textarea id="VideoDescription" ></textarea>
             </div>
-            <input type="button" id="SubmitButton" value="Submit" onclick="thrimbletrimmerSubmit()"/>
+            <input type="button" id="SubmitButton" value="Submit" onclick="thrimbletrimmerSubmit('EDITED')"/>
+            <input type="button" id="DraftButton" value="Save Draft" onclick="thrimbletrimmerSubmit('UNEDITED')"/>
             <input type="button" id="DownloadButton" value="Download" onclick="thrimbletrimmerDownload()"/>
             <a href="/thrimbletrimmer/dashboard.html">Go To Dashboard</a> | 
             <a id="ManualLinkButton" href="JavaScript:toggleHiddenPane('ManualLinkPane');">Manual Link</a> | 

--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -70,7 +70,7 @@ loadPlaylist = function(startTrim, endTrim) {
     });
 };
 
-thrimbletrimmerSubmit = function() {
+thrimbletrimmerSubmit = function(state) {
     document.getElementById('SubmitButton').disabled = true;
     if(player.trimmingControls().options.startTrim >= player.trimmingControls().options.endTrim) {
         alert("End Time must be greater than Start Time");
@@ -88,7 +88,7 @@ thrimbletrimmerSubmit = function() {
             video_channel:document.getElementById("StreamName").value,
             video_quality:document.getElementById('qualityLevel').options[document.getElementById('qualityLevel').options.selectedIndex].value,
             uploader_whitelist:(document.getElementById('uploaderWhitelist').value ? document.getElementById('uploaderWhitelist').value.split(','):null),
-            state:"EDITED",
+            state:state,
             token: user.getAuthResponse().id_token
         };
         // state_columns = ['state', 'uploader', 'error', 'video_link'] 


### PR DESCRIPTION
Added a "Save Drafts" button to the editor page.
Added "Editing Time" and "Upload Time" to the dashboard page.
If a row doesn't have a description, it won't be displayed (to handle orphaned/cleared rows).

Currently live on editing.live for testing.

Handles the major requests from issue #86.