### PR TITLE
warn about and ignore files that don't parse as segments

### DIFF
--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -11,6 +11,7 @@ import logging
 import os
 import shutil
 import sys
+import warnings
 from collections import namedtuple
 from contextlib import closing
 
@@ -222,7 +223,13 @@ def best_segments_by_start(hour):
 	segment_paths.sort()
 	# note we only parse them as we need them, which is unlikely to save us much time overall
 	# but is easy enough to do, so we might as well.
-	parsed = (parse_segment_path(os.path.join(hour, name)) for name in segment_paths)
+	# raise a warning for any files that don't parse as segments and ignore them
+	parsed = []
+	for name in segment_paths:
+		try:
+			parsed.append(parse_segment_path(os.path.join(hour, name)))
+		except ValueError as e:
+			warnings.warn(e)
 	for start_time, segments in itertools.groupby(parsed, key=lambda segment: segment.start):
 		# ignore temp segments as they might go away by the time we want to use them
 		segments = [segment for segment in segments if segment.type != "temp"]

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -220,8 +220,6 @@ def best_segments_by_start(hour):
 		# path does not exist, treat it as having no files
 		return
 	segment_paths.sort()
-	# note we only parse them as we need them, which is unlikely to save us much time overall
-	# but is easy enough to do, so we might as well.
 	# raise a warning for any files that don't parse as segments and ignore them
 	parsed = []
 	for name in segment_paths:

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -11,7 +11,6 @@ import logging
 import os
 import shutil
 import sys
-import warnings
 from collections import namedtuple
 from contextlib import closing
 
@@ -229,7 +228,8 @@ def best_segments_by_start(hour):
 		try:
 			parsed.append(parse_segment_path(os.path.join(hour, name)))
 		except ValueError as e:
-			warnings.warn(e)
+			logging.warning("Failed to parse segment {!r}".format(os.path.join(hour, name)), exc_info=True)
+
 	for start_time, segments in itertools.groupby(parsed, key=lambda segment: segment.start):
 		# ignore temp segments as they might go away by the time we want to use them
 		segments = [segment for segment in segments if segment.type != "temp"]


### PR DESCRIPTION
`common.segments.best_segments_by_start` now raises a warning and ignores for any files that it is unable to parse as segments rather than letting the `ValueError` from `parse_segment_path` pass.

Fixes #98  