### PR TITLE
nginx: Serve the segments directly from the segments dir

### DIFF
--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -68,6 +68,8 @@
 
   thrimbletrimmer:: true, // set to false to not have nginx serve thrimbletrimmer pages.
 
+  nginx_serve_segments:: true, // set to false to not have nginx serve segments directly, letting restreamer do it instead.
+
   // Connection args for the database.
   // If database is defined in this config, host and port should be postgres:5432.
   db_args:: {
@@ -280,7 +282,9 @@
           if service in $.enabled && $.enabled[service]
         ]),
         THRIMBLETRIMMER: if $.thrimbletrimmer then "true" else "",
+        SEGMENTS: if $.nginx_serve_segments then "/mnt" else "",
       },
+      volumes: if $.nginx_serve_segments then ["%s:/mnt" % $.segments_path] else [],
     },
 
     [if $.enabled.postgres then "postgres"]: {

--- a/nginx/generate-config
+++ b/nginx/generate-config
@@ -3,6 +3,10 @@
 # This script expects a mapping of services and ports in the SERVICES env var,
 # with one line per service containing "NAME PORT".
 
+# Other vars:
+#  THRIMBLETRIMMER: Set non-empty to also serve thrimbletrimmer on /thrimbletrimmer
+#  SEGMENTS: Set to path to segments dir to also serve segments dir on /segments
+
 generate_location() {
 	# generate_location PATH URL
 	echo -e "\t\tlocation $1 { proxy_pass $2; }"
@@ -20,6 +24,8 @@ LOCATIONS=$(
 	[ -n "$THRIMBLETRIMMER" ] &&
 		echo -e "\t\tlocation = / { return 301 /thrimbletrimmer/dashboard.html; }" &&
 		echo -e "\t\tlocation /thrimbletrimmer { }"
+	[ -n "$SEGMENTS" ] &&
+		echo -e "\t\tlocation /segments/ { alias $SEGMENTS/; }"
 )
 
 cat > /etc/nginx/nginx.conf <<EOF


### PR DESCRIPTION
instead of proxying through restreamer.

This should improve performance when serving the (large) segment files,
and free up restreamer for things like generating the playlist.

Fixes #104