### PR TITLE
Chrusher backfiller delete

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -286,10 +286,11 @@ class BackfillerManager(object):
 					# ignore error when file is already deleted
 					if e.errno == errno.ENOENT:
 						self.logger.warn('{} already deleted'.format(path))
-						
 					# warn if not empty (will try to delete folder again next time) 
 					elif e.errno == errno.ENOTEMPTY:
 						self.logger.warn('Failed to delete non-empty folder {}'.format(path))
+					else:
+						raise
 				else:
 					self.logger.info('{} deleted'.format(path))
 
@@ -331,7 +332,7 @@ class BackfillerManager(object):
 			if self.run_once:
 				break
 
-			# if get_nodes() raises an error, this will deletes will not occur
+			# note that if get_nodes() raises an error, then deletes will not occur
 			if self.delete_old and self.start:
 				try:
 					self.delete_hours()

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -278,7 +278,7 @@ class BackfillerManager(object):
 					except OSError as e:
 						# ignore error when the file is already gone
 						if e.errno != errno.ENOENT:
-							pass
+							raise
 
 				try:
 					os.rmdir(path)

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -499,9 +499,13 @@ def main(channels, base_dir='.', qualities='source', metrics_port=8002,
 		try:
 			start = float(start)
 			logging.info('Backfilling last {} hours'.format(start))
+			if delete_before and start > delete_before:
+				logging.warn('Keeping fewer hours ({}) than backfilling ({})'.format(delete_before, start))
 		except ValueError:
 			start = dateutil.parse(start)
-			logging.info('Backfilling since {}'.format(start)) 
+			logging.info('Backfilling since {}'.format(start))
+			if delete_before:
+				logging.warn('Only keeping {} hours when backfilling since {}'.format(delete_before, start))
 
 	common.PromLogCountsHandler.install()
 	common.install_stacksampler()

--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -424,12 +424,13 @@ class BackfillerWorker(object):
 			for hour in hours:
 				# since backfilling can take a long time, recheck whether this
 				# hour is after the start
-				if not isinstance(self.start, datetime.datetime):
-					start_hour = datetime.datetime.utcnow() - datetime.timedelta(hours=self.start)
-				else:
-					start_hour = self.start
-				if datetime.datetime.strptime(hour, HOUR_FMT) < start_hour:
-					break
+				if self.start is not None:
+					if not isinstance(self.start, datetime.datetime):
+						start_hour = datetime.datetime.utcnow() - datetime.timedelta(hours=self.start)
+					else:
+						start_hour = self.start
+					if datetime.datetime.strptime(hour, HOUR_FMT) < start_hour:
+						break
 
 				self.logger.info('Backfilling {}/{}'.format(quality, hour))
 	


### PR DESCRIPTION
Added the option to automatically delete hours older than the number of hours ago (or specific hour) given by `start`.

Fixes #110 