### PR TITLE
Allow thrimshim to safely cancel a job while it is cutting

### DIFF
--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -98,7 +98,8 @@
             <a href="/thrimbletrimmer/dashboard.html">Go To Dashboard</a> | 
             <a href="/thrimbletrimmer/stream.html">Go to Re-stream View</a> |
             <a id="ManualLinkButton" href="JavaScript:toggleHiddenPane('ManualLinkPane');">Manual Link</a> | 
-            <a id="ResetButton" href="JavaScript:thrimbletrimmerResetLink();">Reset Edits</a>
+            <a id="CancelButton" href="JavaScript:thrimbletrimmerResetLink(false);">Cancel Upload</a> |
+            <a id="ResetButton" href="JavaScript:thrimbletrimmerResetLink(true);">Force Reset Row</a>
             <a id="HelpButton" style="float:right;" href="JavaScript:toggleHiddenPane('HelpPane');">Help</a>
             <a id="UltrawideButton" style="float:right;margin-right:10px;" href="JavaScript:toggleUltrawide();">Ultrawide</a>
         </div>

--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -309,9 +309,9 @@ thrimbletrimmerManualLink = function() {
     }));
 };
 
-thrimbletrimmerResetLink = function() {
+thrimbletrimmerResetLink = function(force) {
     var rowId = /id=(.*)(?:&|$)/.exec(document.location.search)[1];
-    if(!confirm(
+    if(force && !confirm(
         'Are you sure you want to reset this event? ' +
         'This will set the row back to UNEDITED and forget about any video that already may exist. ' +
         'It is intended as a last-ditch command to clear a malfunctioning cutter, ' +
@@ -321,11 +321,12 @@ thrimbletrimmerResetLink = function() {
         return;
     }
     document.getElementById("ResetButton").disabled = true;
+    document.getElementById("CancelButton").disabled = true;
     var body = {}
     if (!!user) {
         body.token = user.getAuthResponse().id_token;
     }
-    fetch("/thrimshim/reset/"+rowId, {
+    fetch("/thrimshim/reset/"+rowId + "?force=" + force, {
         method: 'POST',
         headers: {
             'Accept': 'application/json',
@@ -339,8 +340,9 @@ thrimbletrimmerResetLink = function() {
             console.log(error);
             alert(error);
             document.getElementById("ResetButton").disabled = false;
+			document.getElementById("CancelButton").disabled = true;
         } else {
-            alert("Row has been reset. Reloading...");
+            alert("Row has been " + ((force) ? "reset" : "cancelled") +". Reloading...");
             setTimeout(() => { window.location.reload(); }, 500);
         }
     }));


### PR DESCRIPTION
This differs from the existing reset row by only suceeding if the upload is
not in finalizing.

We also make some changes to cutter to handle this situation gracefully.

We then add a button to thrimbletrimmer to do this under the name "Cancel Upload".

Fixes #122