### PR TITLE
restreamer: Add more options for fetching cuts

### DIFF
--- a/common/common/__init__.py
+++ b/common/common/__init__.py
@@ -7,7 +7,7 @@ import errno
 import os
 import random
 
-from .segments import get_best_segments, fast_cut_segments, full_cut_segments, parse_segment_path, SegmentInfo
+from .segments import get_best_segments, rough_cut_segments, fast_cut_segments, full_cut_segments, parse_segment_path, SegmentInfo
 from .stats import timed, PromLogCountsHandler, install_stacksampler
 
 

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -333,7 +333,7 @@ def read_chunks(fileobj, chunk_size=16*1024):
 		yield chunk
 
 
-@timed('cut', type='rough', normalize=lambda _, segments, start, end: (end - start).total_seconds())
+@timed('cut', cut_type='rough', normalize=lambda _, segments, start, end: (end - start).total_seconds())
 def rough_cut_segments(segments, start, end):
 	"""Yields chunks of a MPEGTS video file covering at least the timestamp range,
 	likely with a few extra seconds on either side.
@@ -345,7 +345,7 @@ def rough_cut_segments(segments, start, end):
 				yield chunk
 
 
-@timed('cut', type='fast', normalize=lambda _, segments, start, end: (end - start).total_seconds())
+@timed('cut', cut_type='fast', normalize=lambda _, segments, start, end: (end - start).total_seconds())
 def fast_cut_segments(segments, start, end):
 	"""Yields chunks of a MPEGTS video file covering the exact timestamp range.
 	segments should be a list of segments as returned by get_best_segments().
@@ -433,7 +433,7 @@ def feed_input(segments, pipe):
 
 
 @timed('cut',
-	type=lambda _, segments, start, end, encode_args, stream=False: ("full-streamed" if stream else "full-buffered"),
+	cut_type=lambda _, segments, start, end, encode_args, stream=False: ("full-streamed" if stream else "full-buffered"),
 	normalize=lambda _, segments, start, end, *a, **k: (end - start).total_seconds(),
 )
 def full_cut_segments(segments, start, end, encode_args, stream=False):

--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -333,6 +333,18 @@ def read_chunks(fileobj, chunk_size=16*1024):
 		yield chunk
 
 
+@timed('cut', type='rough', normalize=lambda _, segments, start, end: (end - start).total_seconds())
+def rough_cut_segments(segments, start, end):
+	"""Yields chunks of a MPEGTS video file covering at least the timestamp range,
+	likely with a few extra seconds on either side.
+	This method works by simply concatenating all the segments, without any re-encoding.
+	"""
+	for segment in segments:
+		with open(segment.path) as f:
+			for chunk in read_chunks(f):
+				yield chunk
+
+
 @timed('cut', type='fast', normalize=lambda _, segments, start, end: (end - start).total_seconds())
 def fast_cut_segments(segments, start, end):
 	"""Yields chunks of a MPEGTS video file covering the exact timestamp range.

--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -101,6 +101,14 @@
             <a id="ResetButton" href="JavaScript:thrimbletrimmerResetLink();">Reset Edits</a>
             <a id="HelpButton" style="float:right;" href="JavaScript:toggleHiddenPane('HelpPane');">Help</a>
             <a id="UltrawideButton" style="float:right;margin-right:10px;" href="JavaScript:toggleUltrawide();">Ultrawide</a>
+			<br/>
+			Download type:
+			<select id="DownloadType">
+				<option value="rough" selected>Rough (fastest, pads start and end by a few seconds)</option>
+				<option value="fast">Fast (may have artifacts a few seconds in from start and end)</option>
+				<option value="mpegts">MPEG-TS (slow, consumes server resources)</option>
+				<option value="mp4">MP4 (slower, consumes server resources, output is MP4 file)</option>
+			</select>
         </div>
         <div id="ManualLinkPane" style="display:none">
             <input id="ManualLink" /> <input type="button" id="ManualButton" onclick="thrimbletrimmerManualLink()" value="Set Link" />

--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -274,6 +274,11 @@ thrimbletrimmerDownload = function(isEditor) {
         "?" + buildQuery({
             start: range.start,
             end: range.end,
+			// In non-editor, always use rough cut. They don't have the edit controls to do
+			// fine time selection anyway.
+			type: (isEditor) ? (
+				document.getElementById('DownloadType').options[document.getElementById('DownloadType').options.selectedIndex].value
+			) : "rough",
             // Always allow holes in non-editor, accidentially including holes isn't important
             allow_holes: (isEditor) ? String(document.getElementById('AllowHoles').checked) : "true",
         });


### PR DESCRIPTION
Split full cut into two types - an mpegts one and an mp4 one. Add "rough"
cut which is just a concat of the segments.

thrimbletrimmer: Add option to select cut type for Download button

In most cases, you want "rough" because you're going to trim the resulting 
video later anyway.

Fixes #121