### PR TITLE
Automatically set default encoding to utf-8 when common is imported

### DIFF
--- a/common/common/__init__.py
+++ b/common/common/__init__.py
@@ -2,6 +2,13 @@
 """A place for common utilities between wubloader components"""
 
 
+# HACK: This sets the default encoding for the entire process.
+# It is possible this may break (badly-written) third party libs.
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+
 import datetime
 import errno
 import os


### PR DESCRIPTION
To be clear, this is an awful hack.

It means that any implicit str/unicode coersion will use the utf-8 encoding,
which is basically always what you want.

However, it is possible that some badly-written libraries might be relying
on the default encoding being ascii, and will do weird things as a result.

Finally, it's especially hacky to be doing this as part of importing a library.
Normally you're meant to do this as part of a sitecustomize.py in your python system directory,
and the function is deleted before passing control to normal code (this is why we need
to reload() to get it back).