### PR TITLE
Add ability to explicitly pull and re-use layers from other commits when building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
 - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then export PUSH=latest; fi
 # log into quay.io so we can push
 - echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USER" --password-stdin
-# build and push all components
-- ./build
+# build and push all components. Try to pull and re-use layers from images for all parent commits.
+- 'CACHE_FROM=$(git rev-list HEAD -n1 --parents | cut -d" " -f 2-) ./build'

--- a/build
+++ b/build
@@ -26,6 +26,25 @@ if [ "$#" -gt 0 ]; then
 	COMPONENTS=("$@")
 fi
 
+# If CACHE_FROM is set, explicitly pull and re-use specified image versions
+CACHE_IMAGES=()
+CACHE_ARGS=()
+if [ -n "${CACHE_FROM:-}" ]; then
+	# Note lack of quotes here - we want to word split
+	for commit in $CACHE_FROM; do
+		tag=$(git rev-parse --short "$commit")
+		for component in "${COMPONENTS[@]}"; do
+			CACHE_IMAGES+=("$BASE/wubloader-$component:$tag")
+			CACHE_ARGS+=("--cache-from" "$BASE/wubloader-$component:$tag")
+		done
+	done
+	echo "Trying to pull images for commits $CACHE_FROM if they exist, to re-use layers if possible"
+	for image in "${CACHE_IMAGES[@]}"; do
+		echo "Pulling $image"
+		docker pull "$image" || true # don't exit on failure
+	done
+fi
+
 for component in "${COMPONENTS[@]}"; do
 	echo "Building image for $component"
 	latest="$BASE/wubloader-$component:latest"
@@ -34,6 +53,7 @@ for component in "${COMPONENTS[@]}"; do
 		-f "$component/Dockerfile" \
 		-t "$latest" \
 		-t "$specific" \
+		"${CACHE_ARGS[@]}" \
 		.
 	echo "Built image wubloader-$component:$TAG"
 	if [ -n "$PUSH" ]; then


### PR DESCRIPTION
This is intended mainly for travis CI, because by default it doesn't cache any layers
between builds.

By pulling likely-reusable builds (all parents of the current commit),
we take a fixed cost slowdown but in many cases should see a dramatic speed increase
overall, since we won't need to re-build anything that hasn't changed.

This isn't needed for local builds, where docker will do this on its own
with any previously-built images.