### PR TITLE
sheetsync: Move column indexes to match updated sheet

### DIFF
--- a/sheetsync/sheetsync/main.py
+++ b/sheetsync/sheetsync/main.py
@@ -91,11 +91,11 @@ class SheetSync(object):
 			'image_links': 6,
 			'marked_for_edit': 7,
 			'notes': 8,
-			'video_link': 10,
-			'state': 11,
-			'edit_link': 12,
-			'error': 13,
-			'id': 14,
+			'video_link': 11,
+			'state': 12,
+			'edit_link': 13,
+			'error': 14,
+			'id': 15,
 		}
 		# Maps column names to a function that parses that column's value.
 		# Functions take a single arg (the value to parse) and ValueError is


### PR DESCRIPTION
New tags column shunts all columns after it right by 1.
We will later want to parse that, but for now we ignore it.