### PR TITLE
Fix a bug when we fail to load a playlist that prevents loading other playlists

### DIFF
--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -199,7 +199,7 @@ loadPlaylist = function(isEditor, startTrim, endTrim, defaultQuality) {
     var queryString = buildQuery(range);
 
 	// Preserve existing edit times
-	if (player && player.trimmingControls) {
+	if (player && player.trimmingControls && player.vhs.playlists.master) {
 		var discontinuities = mapDiscontinuities();
 		if (!startTrim) {
 			startTrim = getRealTimeForPlayerTime(discontinuities, player.trimmingControls().options.startTrim);


### PR DESCRIPTION
This is a new failure case that occurs when the playlist call fails entirely (eg. 404
because the stream doesn't exist) instead of returning an empty playlist.