### PR TITLE
Add TLS settings to k8s.jsonnet

### DIFF
--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -43,7 +43,14 @@
 
     // The hostname to use in the Ingress
     ingress_host: "wubloader.example.com",
-    
+
+    // Set to true to let the ingress handle TLS
+    ingress_tls: true,
+
+    // Set to true and give a secretName for ingress, if required for ingress TLS
+    ingress_secret_name_needed: false,
+    ingress_secret_name: "wubloader/tls",
+
     // Connection args for the database.
     // If database is defined in this config, host and port should be postgres:5432.
     db_args: {
@@ -232,8 +239,15 @@
             },
           },
         ],
+        [if ($.config.ingress_tls) then 'tls']: [
+            {
+                hosts: [
+                    $.config.ingress_host,
+                ],
+                [if ($.config.ingress_secret_name_needed) then 'secretName']: $.config.ingress_secret_name,
+            },
+        ],
       },
     },
   ],
-
 }

--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -47,9 +47,11 @@
     // Set to true to let the ingress handle TLS
     ingress_tls: true,
 
-    // Set to true and give a secretName for ingress, if required for ingress TLS
-    ingress_secret_name_needed: false,
-    ingress_secret_name: "wubloader-tls",
+    // Uncomment and give a secretName for ingress, if required for ingress TLS
+    //ingress_secret_name: "wubloader-tls",
+
+    // Additional metadata labels for Ingress (cert-manager, etc.) - uncomment if needed, adjust as necessary
+    //ingress_labels: {"cert-manager.io/cluster-issuer": "name-of-issuer"},
 
     // Connection args for the database.
     // If database is defined in this config, host and port should be postgres:5432.
@@ -208,7 +210,7 @@
       apiVersion: "networking.k8s.io/v1beta1",
       metadata: {
         name: "wubloader",
-        labels: {app: "wubloader"},
+        labels: {app: "wubloader"} + (if (std.objectHas($.config, "ingress_labels")) then $.config.ingress_labels else {}),
       },
       spec: {
         rules: [
@@ -244,7 +246,7 @@
                 hosts: [
                     $.config.ingress_host,
                 ],
-                [if ($.config.ingress_secret_name_needed) then 'secretName']: $.config.ingress_secret_name,
+                [if (std.objectHas($.config, "ingress_secret_name")) then 'secretName']: $.config.ingress_secret_name,
             },
         ],
       },

--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -49,7 +49,7 @@
 
     // Set to true and give a secretName for ingress, if required for ingress TLS
     ingress_secret_name_needed: false,
-    ingress_secret_name: "wubloader/tls",
+    ingress_secret_name: "wubloader-tls",
 
     // Connection args for the database.
     // If database is defined in this config, host and port should be postgres:5432.

--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -50,8 +50,8 @@
     // Uncomment and give a secretName for ingress, if required for ingress TLS
     //ingress_secret_name: "wubloader-tls",
 
-    // Additional metadata labels for Ingress (cert-manager, etc.) - uncomment if needed, adjust as necessary
-    //ingress_labels: {"cert-manager.io/cluster-issuer": "name-of-issuer"},
+    // Additional metadata labels for Ingress (cert-manager, etc.) - adjust as needed for your setup
+    ingress_labels: {},
 
     // Connection args for the database.
     // If database is defined in this config, host and port should be postgres:5432.
@@ -210,7 +210,7 @@
       apiVersion: "networking.k8s.io/v1beta1",
       metadata: {
         name: "wubloader",
-        labels: {app: "wubloader"} + (if (std.objectHas($.config, "ingress_labels")) then $.config.ingress_labels else {}),
+        labels: {app: "wubloader"} + $.config.ingress_labels,
       },
       spec: {
         rules: [
@@ -241,12 +241,12 @@
             },
           },
         ],
-        [if ($.config.ingress_tls) then 'tls']: [
+        [if $.config.ingress_tls then 'tls']: [
             {
                 hosts: [
                     $.config.ingress_host,
                 ],
-                [if (std.objectHas($.config, "ingress_secret_name")) then 'secretName']: $.config.ingress_secret_name,
+                [if "ingress_secret_name" in $.config then 'secretName']: $.config.ingress_secret_name,
             },
         ],
       },


### PR DESCRIPTION
I modified k8s.jsonnet to let me easily toggle ingress TLS on and off, figured I might as well get that change into the repo.

As it is, it simply adds a `tls` snippet to the Ingress spec if `$.config.ingress_tls` is true, and additionally adds a `secretName` to the `tls` snippet if `$.config.ingress_secret_name_required` is true. (getting the secretName from `$.config.ingress_secret_name`)

The added settings should handle most kubernetes ingress TLS situations, unless one's using cert-manager or something similar to auto-generate certificates and store those in ingress.spec.tls.secretName, that would require some metadata labels.
I use a wildcard cert myself so I haven't poked around with that yet.

Might add that change later, since I've been thinking of moving to per-subdomain certificates in my cluster to reduce reliance on my DNS provider.