### PR TITLE
Detect new style of twitch in-stream ads

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -43,6 +43,12 @@ latest_segment = prom.Gauge(
 	["channel", "quality"],
 )
 
+ad_segments_ignored = prom.Counter(
+	"ad_segments_ignored",
+	"Number of ad segments we saw and avoided downloading",
+	["channel", "quality"],
+)
+
 
 class TimedOutError(Exception):
 	pass
@@ -358,7 +364,8 @@ class StreamWorker(object):
 			date = None # tracks date in case some segment doesn't include it
 			for segment in playlist.segments:
 				if segment.ad_reason:
-					self.logger.debug("Ignoring ad segment: {}".format(segment.ad_reason))
+					self.logger.info("Ignoring ad segment: {}".format(segment.ad_reason))
+					ad_segments_ignored.labels(self.manager.channel, self.quality).inc()
 					continue
 
 				# We've got our first non-ad segment, so we're good to take it from here.

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -357,8 +357,8 @@ class StreamWorker(object):
 			# Start any new segment getters
 			date = None # tracks date in case some segment doesn't include it
 			for segment in playlist.segments:
-				if segment.scte35:
-					self.logger.debug("Ignoring ad segment for {}".format(segment.scte35))
+				if segment.ad_reason:
+					self.logger.debug("Ignoring ad segment: {}".format(segment.ad_reason))
 					continue
 
 				# We've got our first non-ad segment, so we're good to take it from here.


### PR DESCRIPTION
New ad segments always have a title like "Amazon|...". This is the same fix
as used by streamlink at time of writing.

Fixes #164