### PR TITLE
Replace calls to gevent.signal() with gevent.signal_handler()

### DIFF
--- a/backfiller/backfiller/main.py
+++ b/backfiller/backfiller/main.py
@@ -573,7 +573,7 @@ def main(channels, base_dir='.', qualities='source', metrics_port=8002,
 	def stop():
 		manager.stop()
 
-	gevent.signal(signal.SIGTERM, stop)
+	gevent.signal_handler(signal.SIGTERM, stop)
 
 	if backdoor_port:
 		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()

--- a/cutter/cutter/main.py
+++ b/cutter/cutter/main.py
@@ -602,7 +602,7 @@ def main(
 	tags = tags.split(',') if tags else []
 
 	stop = gevent.event.Event()
-	gevent.signal(signal.SIGTERM, stop.set) # shut down on sigterm
+	gevent.signal_handler(signal.SIGTERM, stop.set) # shut down on sigterm
 
 	logging.info("Starting up")
 

--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -597,7 +597,7 @@ def main(channels, base_dir=".", qualities="source", metrics_port=8001, backdoor
 		for manager in managers:
 			manager.stop()
 
-	gevent.signal(signal.SIGTERM, stop) # shut down on sigterm
+	gevent.signal_handler(signal.SIGTERM, stop) # shut down on sigterm
 
 	common.PromLogCountsHandler.install()
 	common.install_stacksampler()

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -332,7 +332,7 @@ def main(host='0.0.0.0', port=8000, base_dir='.', backdoor_port=0):
 	def stop():
 		logging.info("Shutting down")
 		server.stop()
-	gevent.signal(signal.SIGTERM, stop)
+	gevent.signal_handler(signal.SIGTERM, stop)
 
 	PromLogCountsHandler.install()
 	install_stacksampler()

--- a/segment_coverage/segment_coverage/main.py
+++ b/segment_coverage/segment_coverage/main.py
@@ -565,7 +565,7 @@ def main(channels, base_dir='.', qualities='source', first_hour=None,
 		for manager in managers:
 			manager.stop()
 
-	gevent.signal(signal.SIGTERM, stop)
+	gevent.signal_handler(signal.SIGTERM, stop)
 
 	if backdoor_port:
 		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()

--- a/sheetsync/sheetsync/main.py
+++ b/sheetsync/sheetsync/main.py
@@ -372,7 +372,7 @@ def main(dbconnect, sheets_creds_file, edit_url, bustime_start, sheet_id, worksh
 		gevent.backdoor.BackdoorServer(('127.0.0.1', backdoor_port), locals=locals()).start()
 
 	stop = gevent.event.Event()
-	gevent.signal(signal.SIGTERM, stop.set) # shut down on sigterm
+	gevent.signal_handler(signal.SIGTERM, stop.set) # shut down on sigterm
 
 	logging.info("Starting up")
 

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -354,7 +354,7 @@ def main(connection_string, default_channel, bustime_start, host='0.0.0.0', port
 		# and when not
 		else:
 			sys.exit()
-	gevent.signal(signal.SIGTERM, stop)
+	gevent.signal_handler(signal.SIGTERM, stop)
 
 	app.db_manager = database.DBManager(dsn=connection_string)
 


### PR DESCRIPTION
gevent.signal() was removed in gevent 1.5a4, see http://www.gevent.org/api/gevent.signal.html

Removed on Feb 5th, see https://github.com/gevent/gevent/pull/1530
