### PR TITLE
Use psycopg2-binary instead of psycopg2

### DIFF
--- a/backfiller/setup.py
+++ b/backfiller/setup.py
@@ -8,7 +8,7 @@ setup(
 		"argh",
 		"gevent",
 		"psycogreen",
-		"psycopg2",
+		"psycopg2-binary",
 		"python-dateutil",
 		"requests",
 		"wubloader-common",

--- a/cutter/setup.py
+++ b/cutter/setup.py
@@ -9,7 +9,7 @@ setup(
 		"gevent",
 		"prometheus-client",
 		"psycogreen",
-		"psycopg2",
+		"psycopg2-binary",
 		"requests",
 		"wubloader-common",
 	],

--- a/playlist_manager/setup.py
+++ b/playlist_manager/setup.py
@@ -9,7 +9,7 @@ setup(
 		"gevent",
 		"prometheus-client",
 		"psycogreen",
-		"psycopg2",
+		"psycopg2-binary",
 		"requests",
 		"wubloader-common",
 	],

--- a/sheetsync/setup.py
+++ b/sheetsync/setup.py
@@ -9,7 +9,7 @@ setup(
 		"gevent",
 		"prometheus-client==0.7.1", # locked version as we rely on internals
 		"psycogreen",
-		"psycopg2",
+		"psycopg2-binary",
 		"python-dateutil",
 		"requests",
 		"wubloader-common",

--- a/thrimshim/setup.py
+++ b/thrimshim/setup.py
@@ -10,7 +10,7 @@ setup(
 		"gevent",
 		"google-auth",
 		"psycogreen",
-		"psycopg2",
+		"psycopg2-binary",
 		"requests",
 		"wubloader-common",
 	],


### PR DESCRIPTION
It's identical except we download pre-built binaries.
This makes builds faster and requires less dependencies.