### PR TITLE
downloader: Fix a bug when we can't find a particular stream quality

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -221,6 +221,7 @@ class StreamsManager(object):
 				if quality not in new_urls:
 					self.logger.warning("Stream {} could not be found in latest master playlist, re-queueing refresh".format(quality))
 					self.trigger_refresh()
+					continue
 				# is it newly found?
 				if not workers and quality in self.latest_urls:
 					self.logger.info("Starting new worker for {} as none exist".format(quality))


### PR DESCRIPTION
The intended behaviour was to log a warning message and retry next time,
but still allow workers to be started for any streams found.

However, due to a missing continue, we fall through to attempting to start a worker
for a non-existent quality which causes a KeyError when looking up
`self.latest_urls[quality]`. This exception means we don't run through the other qualities,
so we never start any other quality.