### PR TITLE
Disable stacksampler by default

### DIFF
--- a/common/common/stats.py
+++ b/common/common/stats.py
@@ -194,9 +194,10 @@ def install_stacksampler(interval=0.005):
 	We could use user+sys time but that leads to interrupting syscalls,
 	which may affect performance, and we care mostly about user time anyway.
 	"""
-	if os.environ.get('WUBLOADER_DISABLE_STACKSAMPLER', '').lower() == 'true':
-		logging.info("Not installing stacksampler - disabled by WUBLOADER_DISABLE_STACKSAMPLER env var")
+	if os.environ.get('WUBLOADER_ENABLE_STACKSAMPLER', '').lower() != 'true':
 		return
+
+	logging.info("Installing stacksampler")
 
 	# Note we only start each next timer once the previous timer signal has been processed.
 	# There are two reasons for this:

--- a/docker-compose.jsonnet
+++ b/docker-compose.jsonnet
@@ -151,8 +151,8 @@
   env:: {
     // Uncomment this to set log level to debug
     // WUBLOADER_LOG_LEVEL: "DEBUG",
-    // Uncomment this to disable stacksampling performance monitoring
-    // WUBLOADER_DISABLE_STACKSAMPLER: "true",
+    // Uncomment this to enable stacksampling performance monitoring
+    // WUBLOADER_ENABLE_STACKSAMPLER: "true",
   },
 
   // Now for the actual docker-compose config

--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -86,8 +86,8 @@
     env: {
       // Uncomment this to set log level to debug
       // WUBLOADER_LOG_LEVEL: "DEBUG",
-      // Uncomment this to disable stacksampling performance monitoring
-      // WUBLOADER_DISABLE_STACKSAMPLER: "true",
+      // Uncomment this to enable stacksampling performance monitoring
+      // WUBLOADER_ENABLE_STACKSAMPLER: "true",
     },
     
     // Config for cutter upload locations. See cutter docs for full detail.


### PR DESCRIPTION
It causes problems due to the sheer number of unique metrics emitted, which makes
the prometheus endpoint be very expensive / fail a lot.

The data is not useful enough to justify the cost.