### PR TITLE
Fix metrics on k8s

### DIFF
--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -289,10 +289,11 @@
               },
               local metric_rule(name) = rule(name, "/metrics/%s" % name, "Exact"),
               paths: [
-                // Map /metrics/NAME to each service (except restreamer)
+                // Map /metrics/NAME to each service
                 metric_rule("downloader"),
                 metric_rule("backfiller"),
-                metric_rule("segment-coverage"),
+                metric_rule("restreamer"),
+                metric_rule("segment_coverage"),
                 metric_rule("thrimshim"),
                 // Map /segments and /thrimbletrimmer to the static content nginx
                 rule("nginx", "/segments", "Prefix"),

--- a/k8s.jsonnet
+++ b/k8s.jsonnet
@@ -283,7 +283,7 @@
                 path: path,
                 pathType: type,
                 backend: {
-                  serviceName: "wubloader-%s" % name,
+                  serviceName: "wubloader-%s" % std.strReplace(name, "-", "_"),
                   servicePort: 80,
                 },
               },

--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -86,6 +86,13 @@ def metrics():
 	"""Return current metrics in prometheus metrics format"""
 	return prom.generate_latest()
 
+# To make nginx proxying simpler, we want to allow /metrics/* to work
+@app.route('/metrics/<trailing>')
+@request_stats
+def metrics_with_trailing(trailing):
+       """Expose Prometheus metrics."""
+       return prometheus_client.generate_latest()
+
 @app.route('/files')
 @request_stats
 def list_channels():

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -90,6 +90,13 @@ def authenticate(f):
 def test(editor=None):
 	return json.dumps(editor)
 
+# To make nginx proxying simpler, we want to allow /metrics/* to work
+@app.route('/metrics/<trailing>')
+@request_stats
+def metrics_with_trailing(trailing):
+	"""Expose Prometheus metrics."""
+	return prometheus_client.generate_latest()
+
 @app.route('/metrics')
 @request_stats
 def metrics():


### PR DESCRIPTION
Fixes k8s.jsonnet to have metrics rules for all services.

As a hack to work around the fact ingress doesn't rewrite the path,
we make restreamer and thrimshim allow `/metrics/ANYTHING` in addition to `/metrics` endpoints.