### PR TITLE
common: When parsing segment timestamps, use decimal instead of float

### DIFF
--- a/common/common/segments.py
+++ b/common/common/segments.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 from collections import namedtuple
 from contextlib import closing
+from decimal import Decimal
 from tempfile import TemporaryFile
 
 import gevent
@@ -53,7 +54,7 @@ def parse_segment_timestamp(hour_str, min_str):
 	day = int(hour_str[8:10])
 	hour = int(hour_str[11:13])
 	min = int(min_str[0:2])
-	sec_float = float(min_str[3:])
+	sec_float = Decimal(min_str[3:])
 	sec = int(sec_float)
 	microsec = int(1000000 * (sec_float % 1))
 	return datetime.datetime(year, month, day, hour, min, sec, microsec)


### PR DESCRIPTION
Floating point error leads to 1us differences in parsed times,
which causes false positives in the overlapping segments check.

By using a Decimal, we get the exact digits from the filepath.