### PR TITLE
thrimshim: Fix a bug preventing submissions

### DIFF
--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -250,7 +250,11 @@ def update_row(ident, editor=None):
 	for column in sheet_columns:
 		if isinstance(old_row[column], datetime.datetime):
 			old_row[column] = old_row[column].isoformat()
-		if new_row[column].lower().strip() != old_row[column].lower().strip():
+		def normalize(value):
+			if isinstance(value, list):
+				return sorted(map(normalize, value))
+			return value.lower().strip()
+		if normalize(new_row[column]) != normalize(old_row[column]):
 			changes += '{}: {} => {}\n'.format(column, new_row[column], old_row[column])
 	if changes and not override_changes:
 		return 'Sheet columns have changed since editing has begun. Please review changes\n' + changes, 409


### PR DESCRIPTION
When comparing old and new video tags, it errors because it's a list, not string.

We change it to apply the transforms to all tags in the list, and also ignore changes in list ordering.