### PR TITLE
Add an alternate manual upload mode specifically for youtube

### DIFF
--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -119,7 +119,7 @@
         </div>
         <div id="ManualLinkPane" style="display:none">
             <input id="ManualLink" /> <input type="button" id="ManualButton" onclick="thrimbletrimmerManualLink()" value="Set Link" />
-        </div>
+            Is Youtube Upload (add to playlists)? <input id="ManualYoutube" type="checkbox" />
         <div id="HelpPane" style="display:none;">
             <ul>
                 <li>J/K/L - Back 10 seconds, Play/Pause, Advance 10 seconds</li>

--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -340,7 +340,8 @@ thrimbletrimmerDownload = function(isEditor) {
 thrimbletrimmerManualLink = function() {
     document.getElementById("ManualButton").disabled = true;
     var rowId = /id=(.*)(?:&|$)/.exec(document.location.search)[1];
-    var body = {link: document.getElementById("ManualLink").value};
+	var upload_location = (document.getElementById("ManualYoutube").checked) ? "youtube-manual" : "manual";
+    var body = {link: document.getElementById("ManualLink").value, upload_location: upload_location};
     if (!!user) {
         body.token = user.getAuthResponse().id_token;
     }


### PR DESCRIPTION
Adds a built-in "youtube-manual" location which is like "manual" except that it only works
with youtube URLs and populates the video_id column.

The intent is so that we can have playlist_manager manage videos we upload manually,
while still being able to distinguish between that and other manual links that shouldn't
be included (eg. links to third party youtube videos).

This is set when setting a manual link in thrimbletrimmer with a new checkbox, default off.