### PR TITLE
Change wording on edit submitted alert()

### DIFF
--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -299,7 +299,7 @@ thrimbletrimmerSubmit = function(state, override_changes=false) {
                 alert(error);
             }
         } else if (state == 'EDITED') {
-			alert(`Video submitted for edit from ${start} to ${end}`)
+			alert(`Edit submitted for video from ${start} to ${end}`)
         } else {
 			alert("Draft saved");
 		}


### PR DESCRIPTION
An edit has been submitted for the video. The video hasn't been submitted yet, thrimbletrimmer just informs other components how it wants the edit to be.

This is EXTREMELY nitpicky but it annoyed a tiny part of my brain every dang time I saw that alert dialog >_>