### PR TITLE
Display a waveform graph in thrimbletrimmer

### DIFF
--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -79,6 +79,7 @@
         </div>
 
         <div id="EditorDetailsPane">
+			<img id="Waveform" style="width: 100%">
             <div id="EditNotesPane" style="display:none">
                 Edit Notes: <br/>
                 <textarea id="EditNotes" disabled ></textarea>

--- a/thrimbletrimmer/scripts/IO.js
+++ b/thrimbletrimmer/scripts/IO.js
@@ -272,6 +272,10 @@ function loadPlaylist(isEditor, startTrim, endTrim, defaultQuality) {
 				document.getElementById("wubloaderAdvancedInputTable").style.display = "block";
 			}
 		});
+
+	// Get audio waveform. Note we assume "source" is a valid quality.
+	const waveformURL = `/waveform/${stream}/source.png?${buildQuery(range)}`;
+	document.getElementById("Waveform").setAttribute("src", waveformURL);
 }
 
 function thrimbletrimmerSubmit(state, override_changes = false) {


### PR DESCRIPTION
This is helpful for finding long silences, etc.
We add a new restreamer endpoint to serve the image. Images are generated on the fly,
it's pretty cheap.

Fixes #216