### PR TITLE
Thrimbletrimmer Fixes 2021 Roundup #3

### DIFF
--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -81,5 +81,38 @@
 			</div>
 		</div>
 		<a href="#" id="download">Download Video</a>
+		<a href="#" id="time-converter-link">Convert Times</a>
+		<form id="time-converter" class="hidden">
+			<h2>Time Converter</h2>
+			<div id="time-converter-time-container">
+				<input class="time-converter-time" type="text" placeholder="Time to convert" />
+			</div>
+			<img
+				src="images/plus.png"
+				id="time-converter-add-time"
+				tooltip="Add time conversion field"
+				class="click"
+				tabindex="0"
+			/>
+			<div>
+				From:
+				<input name="time-converter-from" id="time-converter-from-utc" type="radio" value="1" />
+				<label for="time-converter-from-utc">UTC</label>
+				<input name="time-converter-from" id="time-converter-from-bus" type="radio" value="2" />
+				<label for="time-converter-from-bus">Bus Time</label>
+				<input name="time-converter-from" id="time-converter-from-ago" type="radio" value="3" />
+				<label for="time-converter-from-ago">Time Ago</label>
+			</div>
+			<div>
+				To:
+				<input name="time-converter-to" id="time-converter-to-utc" type="radio" value="1" />
+				<label for="time-converter-to-utc">UTC</label>
+				<input name="time-converter-to" id="time-converter-to-bus" type="radio" value="2" />
+				<label for="time-converter-to-bus">Bus Time</label>
+				<input name="time-converter-to" id="time-converter-to-ago" type="radio" value="3" />
+				<label for="time-converter-to-ago">Time Ago</label>
+			</div>
+			<button type="submit">Convert Times</button>
+		</form>
 	</body>
 </html>

--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -110,7 +110,7 @@ function updateVideoPlayer(newPlaylistURL) {
 	player.src({ src: rangedPlaylistURL });
 }
 
-function parseHumanTimeStringAsDateTimeMathObject(inputTime) {
+function parseHumanTimeStringAsDateTime(inputTime) {
 	// We need to handle inputs like "-0:10:15" in a way that consistently makes the time negative.
 	// Since we can't assign the negative sign to any particular part, we'll check for the whole thing here.
 	let direction = 1;
@@ -127,7 +127,7 @@ function parseHumanTimeStringAsDateTimeMathObject(inputTime) {
 }
 
 function dateTimeFromBusTime(busTime) {
-	return globalBusStartTime.plus(parseHumanTimeStringAsDateTimeMathObject(busTime));
+	return globalBusStartTime.plus(parseHumanTimeStringAsDateTime(busTime));
 }
 
 function busTimeFromDateTime(dateTime) {

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -151,33 +151,10 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 	}
 
 	document.getElementById("video-info-title").addEventListener("input", (_event) => {
-		const videoTitleField = document.getElementById("video-info-title");
-		const videoTitle = videoTitleField.value;
-		if (videoTitle.length > videoInfo.title_max_length) {
-			videoTitleField.classList.add("input-error");
-			videoTitleField.title = "Title is too long";
-		} else if (videoTitle.indexOf("<") !== -1 || videoTitle.indexOf(">") !== -1) {
-			videoTitleField.classList.add("input-error");
-			videoTitleField.title = "Title contains invalid characters";
-		} else {
-			videoTitleField.classList.remove("input-error");
-			videoTitleField.title = "";
-		}
+		validateVideoTitle();
 	});
-
 	document.getElementById("video-info-description").addEventListener("input", (_event) => {
-		const videoDescField = document.getElementById("video-info-description");
-		const videoDesc = videoDescField.value;
-		if (videoDesc.length > 5000) {
-			videoDescField.classList.add("input-error");
-			videoDescField.title = "Description is too long";
-		} else if (videoDesc.indexOf("<") !== -1 || videoDesc.indexOf(">") !== -1) {
-			videoDescField.classList.add("input-error");
-			videoDescField.title = "Description contains invalid characters";
-		} else {
-			videoDescField.classList.remove("input-error");
-			videoDescField.title = "";
-		}
+		validateVideoDescription();
 	});
 
 	document.getElementById("submit-button").addEventListener("click", (_event) => {
@@ -334,6 +311,7 @@ async function initializeVideoInfo() {
 	} else {
 		titleElem.value = videoInfo.description;
 	}
+	validateVideoTitle();
 
 	const descriptionElem = document.getElementById("video-info-description");
 	if (videoInfo.video_description) {
@@ -341,6 +319,7 @@ async function initializeVideoInfo() {
 	} else {
 		descriptionElem.value = videoInfo.description;
 	}
+	validateVideoDescription();
 
 	const tagsElem = document.getElementById("video-info-tags");
 	if (videoInfo.video_tags) {
@@ -482,6 +461,36 @@ function getEndTime() {
 		return null;
 	}
 	return dateTimeFromWubloaderTime(globalEndTimeString);
+}
+
+function validateVideoTitle() {
+	const videoTitleField = document.getElementById("video-info-title");
+	const videoTitle = videoTitleField.value;
+	if (videoTitle.length > videoInfo.title_max_length) {
+		videoTitleField.classList.add("input-error");
+		videoTitleField.title = "Title is too long";
+	} else if (videoTitle.indexOf("<") !== -1 || videoTitle.indexOf(">") !== -1) {
+		videoTitleField.classList.add("input-error");
+		videoTitleField.title = "Title contains invalid characters";
+	} else {
+		videoTitleField.classList.remove("input-error");
+		videoTitleField.title = "";
+	}
+}
+
+function validateVideoDescription() {
+	const videoDescField = document.getElementById("video-info-description");
+	const videoDesc = videoDescField.value;
+	if (videoDesc.length > 5000) {
+		videoDescField.classList.add("input-error");
+		videoDescField.title = "Description is too long";
+	} else if (videoDesc.indexOf("<") !== -1 || videoDesc.indexOf(">") !== -1) {
+		videoDescField.classList.add("input-error");
+		videoDescField.title = "Description contains invalid characters";
+	} else {
+		videoDescField.classList.remove("input-error");
+		videoDescField.title = "";
+	}
 }
 
 async function submitVideo() {

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -7,12 +7,36 @@ var globalVideoTimeReference = TIME_FRAME_AGO;
 
 window.addEventListener("DOMContentLoaded", async (event) => {
 	commonPageSetup();
+	await loadDefaults();
+
 	const timeSettingsForm = document.getElementById("stream-time-settings");
 	timeSettingsForm.addEventListener("submit", (event) => {
 		event.preventDefault();
 		updateTimeSettings();
 	});
-	await loadDefaults();
+
+	const timeConversionForm = document.getElementById("time-converter");
+	timeConversionForm.addEventListener("submit", (event) => {
+		event.preventDefault();
+		convertEnteredTimes();
+	});
+
+	const timeConversionLink = document.getElementById("time-converter-link");
+	timeConversionLink.addEventListener("click", (_event) => {
+		const timeConversionForm = document.getElementById("time-converter");
+		timeConversionForm.classList.toggle("hidden");
+	});
+
+	const addTimeConversionButton = document.getElementById("time-converter-add-time");
+	addTimeConversionButton.addEventListener("click", (_event) => {
+		const newField = document.createElement("input");
+		newField.classList.add("time-converter-time");
+		newField.type = "text";
+		newField.placeholder = "Time to convert";
+		const container = document.getElementById("time-converter-time-container");
+		container.appendChild(newField);
+	});
+
 	updateTimeSettings();
 });
 
@@ -34,14 +58,7 @@ async function loadDefaults() {
 
 // Gets the start time of the video from settings. Returns an invalid date object if the user entered bad data.
 function getStartTime() {
-	switch (globalVideoTimeReference) {
-		case 1:
-			return dateTimeFromWubloaderTime(globalStartTimeString);
-		case 2:
-			return dateTimeFromBusTime(globalStartTimeString);
-		case 3:
-			return DateTime.now().minus(parseHumanTimeStringAsDateTimeMathObject(globalStartTimeString));
-	}
+	return dateTimeFromTimeString(globalStartTimeString, globalVideoTimeReference);
 }
 
 // Gets the end time of the video from settings. Returns null if there's no end time. Returns an invalid date object if the user entered bad data.
@@ -49,13 +66,17 @@ function getEndTime() {
 	if (globalEndTimeString === "") {
 		return null;
 	}
-	switch (globalVideoTimeReference) {
+	return dateTimeFromTimeString(globalEndTimeString, globalVideoTimeReference);
+}
+
+function dateTimeFromTimeString(timeString, timeStringFormat) {
+	switch (timeStringFormat) {
 		case 1:
-			return dateTimeFromWubloaderTime(globalEndTimeString);
+			return dateTimeFromWubloaderTime(timeString);
 		case 2:
-			return dateTimeFromBusTime(globalEndTimeString);
+			return dateTimeFromBusTime(timeString);
 		case 3:
-			return DateTime.now().minus(parseHumanTimeStringAsDateTimeMathObject(globalEndTimeString));
+			return DateTime.now().setZone("utc").minus(parseHumanTimeStringAsDateTime(timeString));
 	}
 }
 
@@ -112,5 +133,71 @@ function updateStoredTimeSettings() {
 			globalVideoTimeReference = +radioItem.value;
 			break;
 		}
+	}
+}
+
+function convertEnteredTimes() {
+	let timeConvertFrom = undefined;
+	const timeConvertFromSelection = document.querySelectorAll(
+		"#time-converter input[name=time-converter-from]"
+	);
+	for (const convertFromItem of timeConvertFromSelection) {
+		if (convertFromItem.checked) {
+			timeConvertFrom = +convertFromItem.value;
+			break;
+		}
+	}
+	if (!timeConvertFrom) {
+		addError("Failed to convert times - input format not specified");
+		return;
+	}
+
+	let timeConvertTo = undefined;
+	const timeConvertToSelection = document.querySelectorAll(
+		"#time-converter input[name=time-converter-to]"
+	);
+	for (const convertToItem of timeConvertToSelection) {
+		if (convertToItem.checked) {
+			timeConvertTo = +convertToItem.value;
+			break;
+		}
+	}
+	if (!timeConvertTo) {
+		addError("Failed to convert times - output format not specified");
+		return;
+	}
+
+	const timeFieldList = document.getElementsByClassName("time-converter-time");
+	const now = DateTime.now().setZone("utc");
+	for (const timeField of timeFieldList) {
+		const enteredTime = timeField.value;
+		if (enteredTime === "") {
+			continue;
+		}
+
+		let time = dateTimeFromTimeString(enteredTime, timeConvertFrom);
+		if (!time) {
+			addError(
+				`Failed to parse the time '${enteredTime}' as a value of the selected "convert from" time format.`
+			);
+			continue;
+		}
+
+		if (timeConvertTo === TIME_FRAME_UTC) {
+			timeField.value = wubloaderTimeFromDateTime(time);
+		} else if (timeConvertTo === TIME_FRAME_BUS) {
+			timeField.value = busTimeFromDateTime(time);
+		} else if (timeConvertTo === TIME_FRAME_AGO) {
+			const difference = now.diff(time);
+			timeField.value = formatIntervalForDisplay(difference);
+		}
+	}
+
+	if (timeConvertTo === TIME_FRAME_UTC) {
+		document.getElementById("time-converter-from-utc").checked = true;
+	} else if (timeConvertTo === TIME_FRAME_BUS) {
+		document.getElementById("time-converter-from-bus").checked = true;
+	} else if (timeConvertTo === TIME_FRAME_AGO) {
+		document.getElementById("time-converter-from-ago").checked = true;
 	}
 }

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -82,6 +82,7 @@ a,
 #video {
 	width: 100%;
 	max-height: 50vh;
+	overflow: hidden;
 }
 
 /* START BLOCK

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -278,3 +278,8 @@ a,
 .submission-response-success {
 	color: #0c0;
 }
+
+.time-converter-time {
+	display: block;
+	width: 200px;
+}


### PR DESCRIPTION
This is a quicker round fixing a couple things of varying intensity:

- The range endpoints updating when the video load time changes turned out to be massively broken (further described in the relevant commit message). This makes it (and the interaction between ranges and reloading the video in general) work properly.
- Validation on title/description for a video now also applies on page load.
- Since a workflow for time conversion was mentioned during editor training, I added a time conversion tool to the restreamer page. It's not part of the header times like in the old Thrimbletrimmer because I found that to be fairly annoying when quickly entering times, but there is now a tool that does it.