### PR TITLE
Thrimbletrimmer - Fix clip bar placement after video is extended

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -412,9 +412,12 @@ async function initializeVideoInfo() {
 					rangeEndField.value = videoHumanTimeFromWubloaderTime(globalEndTimeString);
 				}
 			}
-			rangeDataUpdated();
 			globalLoadedRangeData = true;
 		}
+		// Although we may or may not have updated the range data here, this is where we know the new video duration.
+		// Because of this, we need to run this to properly update range-dependent things like the clip bar UI,
+		// which require a location.
+		rangeDataUpdated();
 	});
 	player.on("timeupdate", () => {
 		const player = getVideoJS();


### PR DESCRIPTION
I made a bit of a whoopsie in the last PR.
Because of how the clip bar placement is determined and when we were computing it, the clip bar would appear off/shifted compared to its intended location when the video load start/end times are modified.