### PR TITLE
Add support for generating chapter markers in the video description

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -117,37 +117,51 @@
 			</div>
 		</div>
 
+		<div>
+			<input type="checkbox" id="enable-chapter-markers" />
+			<label for="enable-chapter-markers">Add chapter markers to video description</label>
+		</div>
 		<div id="range-definitions">
-			<div class="range-definition-times">
-				<input type="text" class="range-definition-start" />
+			<div>
+				<div class="range-definition-times">
+					<input type="text" class="range-definition-start" />
+					<img
+						src="images/pencil.png"
+						alt="Set range start point to current video time"
+						class="range-definition-set-start click"
+					/>
+					<img
+						src="images/play_to.png"
+						alt="Play from start point"
+						class="range-definition-play-start click"
+					/>
+					<div class="range-definition-between-time-gap"></div>
+					<input type="text" class="range-definition-end" />
+					<img
+						src="images/pencil.png"
+						alt="Set range end point to current video time"
+						class="range-definition-set-end click"
+					/>
+					<img
+						src="images/play_to.png"
+						alt="Play from end point"
+						class="range-definition-play-end click"
+					/>
+					<div class="range-definition-icon-gap"></div>
+					<img
+						src="images/arrow.png"
+						alt="Range affected by keyboard shortcuts"
+						title="Range affected by keyboard shortcuts"
+						class="range-definition-current"
+					/>
+				</div>
+				<div class="range-definition-chapter-markers hidden"></div>
 				<img
-					src="images/pencil.png"
-					alt="Set range start point to current video time"
-					class="range-definition-set-start click"
-				/>
-				<img
-					src="images/play_to.png"
-					alt="Play from start point"
-					class="range-definition-play-start click"
-				/>
-				<div class="range-definition-between-time-gap"></div>
-				<input type="text" class="range-definition-end" />
-				<img
-					src="images/pencil.png"
-					alt="Set range end point to current video time"
-					class="range-definition-set-end click"
-				/>
-				<img
-					src="images/play_to.png"
-					alt="Play from end point"
-					class="range-definition-play-end click"
-				/>
-				<div class="range-definition-icon-gap"></div>
-				<img
-					src="images/arrow.png"
-					alt="Range affected by keyboard shortcuts"
-					title="Range affected by keyboard shortcuts"
-					class="range-definition-current"
+					src="images/plus.png"
+					alt="Add chapter marker"
+					title="Add chapter marker"
+					class="add-range-definition-chapter-marker click hidden"
+					tabindex="0"
 				/>
 			</div>
 		</div>

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -262,6 +262,23 @@ a,
 	margin-top: 2px;
 }
 
+.range-definition-chapter-markers > div {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-left: 30px;
+}
+
+.range-definition-chapter-marker-start {
+	width: 100px;
+	text-align: right;
+}
+
+.add-range-definition-chapter-marker {
+	margin-left: 30px;
+	margin-bottom: 7px;
+}
+
 #video-info {
 	margin: 5px 0;
 	display: grid;


### PR DESCRIPTION
As requested, this adds support in Thrimbletrimmer for generating chapter markers for the YouTube video description. Chapter timestamps should pad with the video load range the same way time range timestamps do. The end result is appended to the video description when submitting to Wubloader.