### PR TITLE
Fix loading chapter marker setting when loading a saved draft edit

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -483,7 +483,6 @@ async function initializeVideoInfo() {
 			if (canAddChapters) {
 				descriptionField.value = description;
 				validateVideoDescription();
-				enableChapterMarkers(true);
 			}
 		} else {
 			const rangeStartField =


### PR DESCRIPTION
This fixes automatically checking the "enable chapter markers" box when there are no chapter markers.