### PR TITLE
Implement tombstoning to allow for segment deletion

### DIFF
--- a/downloader/downloader/main.py
+++ b/downloader/downloader/main.py
@@ -528,7 +528,13 @@ class SegmentGetter(object):
 				raise
 			return False
 		full_prefix = "{}-full".format(self.prefix)
-		return any(candidate.startswith(full_prefix) for candidate in candidates)
+		return any(
+			candidate.startswith(full_prefix)
+				# There's almost no way a matching tombstone could already exist, but just in case
+				# we'll make sure it isn't counted.
+				and not candidate.endswith(".tombstone")
+			for candidate in candidates
+		)
 
 	def get_segment(self):
 		try:

--- a/segment_coverage/segment_coverage/main.py
+++ b/segment_coverage/segment_coverage/main.py
@@ -16,6 +16,7 @@ import prometheus_client as prom
 import common
 from common import dateutil
 from common import database
+from common.segments import list_segment_files
 
 
 segment_count_gauge = prom.Gauge(
@@ -272,12 +273,7 @@ class CoverageChecker(object):
 					# based on common.segments.best_segments_by_start
 					# but more complicated to capture more detailed metrics
 					hour_path = os.path.join(self.base_dir, self.channel, quality, hour)
-					try:
-						segment_names = [name for name in os.listdir(hour_path) if not name.startswith('.')]
-					except OSError as e:
-						if e.errno == errno.ENOENT:
-							self.logger.warning('Hour {} was deleted between finding it and processing it, ignoring'.format(hour))
-							continue 
+					segment_names = list_segment_files(hour_path)
 					segment_names.sort()
 					parsed = []
 					bad_segment_count = 0


### PR DESCRIPTION
Rarely, we find ourselves needing to explicitly delete some data, eg. something that shouldn't
have been public and should be removed from all records.

It would also be nice if we could "clean up" bad versions of the same segment,
which occasionally come up when downloaders have issues.

With our distributed segment database, this is actually rather difficult as deleting the data
from any one server would cause it to be restored from the others. It was only possible
by stopping all backfill, deleting the data on all servers, then starting backfill again.

Here we introduce a more practical approach. An operator creates an empty flag file
with the same name as the segment to be deleted, but with a `.tombstone` extension.
eg. to delete a file `/segments/desertbus/source/2019-11-13T02/45:51.608000-2.0-full-7IS92rssMzoSBQDIevHStbTNy-URRV3Vw-jzZ6pwOZM.ts`,
you would create a tombstone `/segments/desertbus/source/2019-11-13T02/45:51.608000-2.0-full-7IS92rssMzoSBQDIevHStbTNy-URRV3Vw-jzZ6pwOZM.tombstone`.

These tombstone files do two important things:
* They hide the segment from being listed, which both means:
  * It can't be restreamed or put into a video
  * It can't be backfilled to other nodes
* The tombstone files themselves do get backfilled to other nodes, so you only need to mark them on one server.

Once the tombstone has propagated to all nodes, the segment file can be deleted independently on each one.

We chose not to have a tombstone automatically trigger a segment deletion for safety reasons.

Fixes #272