### PR TITLE
thrimbletrimmer: Add link to download the current player frame as an image

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -235,6 +235,7 @@
 					<option value="mpegts">MPEG-TS (slow, consumes server resources)</option>
 				</select>
 				<a id="download-link">Download Video</a>
+				<a href="#" id="download-frame">Download Current Frame as Image</a>
 			</div>
 
 			<div id="data-correction">

--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -126,6 +126,7 @@
 			</div>
 
 			<a href="#" id="download">Download Video</a>
+			<a href="#" id="download-frame">Download Current Frame as Image</a>
 			<a href="#" id="time-converter-link">Convert Times</a>
 			<form id="time-converter" class="hidden">
 				<h2>Time Converter</h2>

--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -419,3 +419,37 @@ function videoPlayerTimeFromVideoHumanTime(videoHumanTime) {
 
 	return hours * 3600 + minutes * 60 + seconds;
 }
+
+function getSegmentList() {
+	return globalPlayer.latencyController.levelDetails.fragments;
+}
+
+function dateTimeFromVideoPlayerTime(videoPlayerTime) {
+	const segmentList = getSegmentList();
+	let segmentStartTime;
+	let segmentStartISOTime;
+	for (const segment of segmentList) {
+		const segmentEndTime = segment.start + segment.duration;
+		if (videoPlayerTime >= segment.start && videoPlayerTime < segmentEndTime) {
+			segmentStartTime = segment.start;
+			segmentStartISOTime = segment.rawProgramDateTime;
+			break;
+		}
+	}
+	if (segmentStartISOTime === undefined) {
+		return null;
+	}
+	const wubloaderDateTime = DateTime.fromISO(segmentStartISOTime);
+	const offset = videoPlayerTime - segmentStartTime;
+	return wubloaderDateTime.plus({ seconds: offset });
+}
+
+function downloadFrame() {
+	const videoElement = document.getElementById("video");
+	const dateTime = dateTimeFromVideoPlayerTime(videoElement.currentTime);
+	const url = `/frame/${globalStreamName}/source.png?timestamp=${wubloaderTimeFromDateTime(dateTime)}`;
+	// Avoid : as it causes problems on Windows
+	const filename = `${dateTime.toFormat("yyyy-LL-dd'T'HH-mm-ss.SSS")}.png`;
+	// TODO REPLACE WITH CORRECT CALL
+	console.log(`Would download ${url} as ${filename}`);
+}

--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -450,6 +450,16 @@ function downloadFrame() {
 	const url = `/frame/${globalStreamName}/source.png?timestamp=${wubloaderTimeFromDateTime(dateTime)}`;
 	// Avoid : as it causes problems on Windows
 	const filename = `${dateTime.toFormat("yyyy-LL-dd'T'HH-mm-ss.SSS")}.png`;
-	// TODO REPLACE WITH CORRECT CALL
-	console.log(`Would download ${url} as ${filename}`);
+	triggerDownload(url, filename);
+}
+
+function triggerDownload(url, filename) {
+	// URL must be same-origin.
+	const link = document.createElement('a');
+	link.setAttribute('download', filename);
+	link.href = url;
+	link.setAttribute('target', '_blank');
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
 }

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -220,6 +220,10 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		updateDownloadLink();
 	});
 
+	document.getElementById("download-frame").addEventListener("click", (_event) => {
+		downloadFrame();
+	});
+
 	document.getElementById("manual-link-update").addEventListener("click", (_event) => {
 		const manualLinkDataContainer = document.getElementById("data-correction-manual-link");
 		manualLinkDataContainer.classList.toggle("hidden");
@@ -1431,26 +1435,6 @@ function videoPlayerTimeFromWubloaderTime(wubloaderTime) {
 	return null;
 }
 
-function dateTimeFromVideoPlayerTime(videoPlayerTime) {
-	const segmentList = getSegmentList();
-	let segmentStartTime;
-	let segmentStartISOTime;
-	for (const segment of segmentList) {
-		const segmentEndTime = segment.start + segment.duration;
-		if (videoPlayerTime >= segment.start && videoPlayerTime < segmentEndTime) {
-			segmentStartTime = segment.start;
-			segmentStartISOTime = segment.rawProgramDateTime;
-			break;
-		}
-	}
-	if (segmentStartISOTime === undefined) {
-		return null;
-	}
-	const wubloaderDateTime = DateTime.fromISO(segmentStartISOTime);
-	const offset = videoPlayerTime - segmentStartTime;
-	return wubloaderDateTime.plus({ seconds: offset });
-}
-
 function videoPlayerTimeFromDateTime(dateTime) {
 	const segmentList = getSegmentList();
 	for (const segment of segmentList) {
@@ -1495,8 +1479,4 @@ function wubloaderTimeFromVideoHumanTime(videoHumanTime) {
 		return null;
 	}
 	return wubloaderTimeFromVideoPlayerTime(videoPlayerTime);
-}
-
-function getSegmentList() {
-	return globalPlayer.latencyController.levelDetails.fragments;
 }

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -28,6 +28,10 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		updateTimeSettings();
 	});
 
+	document.getElementById("download-frame").addEventListener("click", (_event) => {
+		downloadFrame();
+	});
+
 	const timeConversionForm = document.getElementById("time-converter");
 	timeConversionForm.addEventListener("submit", (event) => {
 		event.preventDefault();


### PR DESCRIPTION
This link is updated whenever the player changes time.
We do this in common.js as it is present in both edit and stream.

The intent here is to provide a way for people making custom thumbnails or doing other image stuff
to easily grab a clean copy of a frame from the stream.

Fixes #276

How it looks in the UI:
![screenshot](https://user-images.githubusercontent.com/570052/194200573-2b5403b1-dbe5-409c-813e-b17e9a8367ff.png)
The resulting download:
![2021-11-15T06-29-58 182](https://user-images.githubusercontent.com/570052/194200606-25268ed6-bc6d-4806-90a7-ed12390b34a2.png)
