### PR TITLE
Thrimbletrimmer support for thumbnails

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -224,6 +224,18 @@
 				>
 					<input type="file" id="video-info-thumbnail-custom" accept="image/png" />
 				</div>
+				<div class="video-info-thumbnail-mode-options" id="video-info-thumbnail-template-preview">
+					<button id="video-info-thumbnail-template-preview-generate">
+						Generate Thumbnail Preview
+					</button>
+					<div>
+						<img
+							id="video-info-thumbnail-template-preview-image"
+							class="hidden"
+							alt="Thumbnail preview image"
+						/>
+					</div>
+				</div>
 			</div>
 		</div>
 

--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -190,6 +190,43 @@
 			<textarea id="video-info-description"></textarea>
 			<label for="video-info-tags">Tags (comma-separated):</label>
 			<input type="text" id="video-info-tags" />
+			<label for="video-info-thumbnail-mode">Thumbnail:</label>
+			<div id="video-info-thumbnail">
+				<div>
+					<select id="video-info-thumbnail-mode">
+						<option value="NONE">No custom thumbnail</option>
+						<option value="BARE">Use video frame</option>
+						<option value="TEMPLATE" selected>Use video frame in image template</option>
+						<option value="CUSTOM">Use a custom thumbnail image</option>
+					</select>
+				</div>
+				<div class="video-info-thumbnail-mode-options" id="video-info-thumbnail-template-options">
+					<select id="video-info-thumbnail-template">
+						<!-- TODO Implement options for template selection -->
+					</select>
+				</div>
+				<div class="video-info-thumbnail-mode-options" id="video-info-thumbnail-time-options">
+					<input type="text" id="video-info-thumbnail-time" />
+					<img
+						src="images/pencil.png"
+						alt="Set video thumbnail frame to current video time"
+						class="click"
+						id="video-info-thumbnail-time-set"
+					/>
+					<img
+						src="images/play_to.png"
+						alt="Set video time to video thumbnail frame"
+						class="click"
+						id="video-info-thumbnail-time-play"
+					/>
+				</div>
+				<div
+					class="hidden video-info-thumbnail-mode-options"
+					id="video-info-thumbnail-custom-options"
+				>
+					<input type="file" id="video-info-thumbnail-custom" accept="image/png" />
+				</div>
+			</div>
 		</div>
 
 		<div id="submission">

--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -201,9 +201,7 @@
 					</select>
 				</div>
 				<div class="video-info-thumbnail-mode-options" id="video-info-thumbnail-template-options">
-					<select id="video-info-thumbnail-template">
-						<!-- TODO Implement options for template selection -->
-					</select>
+					<select id="video-info-thumbnail-template"></select>
 				</div>
 				<div class="video-info-thumbnail-mode-options" id="video-info-thumbnail-time-options">
 					<input type="text" id="video-info-thumbnail-time" />

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -208,7 +208,11 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 			unhideIDs.push("video-info-thumbnail-custom-options");
 		}
 
-		document.getElementsByClassName("video-info-thumbnail-mode-options").classList.add("hidden");
+		for (const optionElement of document.getElementsByClassName(
+			"video-info-thumbnail-mode-options"
+		)) {
+			optionElement.classList.add("hidden");
+		}
 		for (elemID of unhideIDs) {
 			document.getElementById(elemID).classList.remove("hidden");
 		}
@@ -235,6 +239,7 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		const thumbnailTemplatesList = await thumbnailTemplatesListResponse.json();
 		for (const templateFileName of thumbnailTemplatesList) {
 			const templateOption = document.createElement("option");
+			// Thumbnails are fetched from restreamer with file extensions. The thumbnail name is the file name.
 			const templateName = templateFileName.substring(0, templateFileName.lastIndexOf("."));
 			templateOption.innerText = templateName;
 			templateOption.value = templateName;
@@ -248,9 +253,11 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 	}
 	document.getElementById("video-info-thumbnail-mode").value = videoInfo.thumbnail_mode;
 	if (videoInfo.thumbnail_time) {
-		document.getElementById("video-info-thumbnail-time").value = videoHumanTimeFromWubloaderTime(
-			videoInfo.thumbnail_time
-		);
+		document.getElementById("video").addEventListener("loadedmetadata", (_event) => {
+			document.getElementById("video-info-thumbnail-time").value = videoHumanTimeFromWubloaderTime(
+				videoInfo.thumbnail_time
+			);
+		});
 	}
 
 	document.getElementById("submit-button").addEventListener("click", (_event) => {

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -204,6 +204,7 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		} else if (newValue === "TEMPLATE") {
 			unhideIDs.push("video-info-thumbnail-template-options");
 			unhideIDs.push("video-info-thumbnail-time-options");
+			unhideIDs.push("video-info-thumbnail-template-preview");
 		} else if (newValue === "CUSTOM") {
 			unhideIDs.push("video-info-thumbnail-custom-options");
 		}
@@ -233,6 +234,22 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		const videoPlayer = document.getElementById("video");
 		videoPlayer.currentTime = thumbnailTime;
 	});
+	document
+		.getElementById("video-info-thumbnail-template-preview-generate")
+		.addEventListener("click", (_event) => {
+			const imageElement = document.getElementById("video-info-thumbnail-template-preview-image");
+			const timeEntryElement = document.getElementById("video-info-thumbnail-time");
+			const imageTime = wubloaderTimeFromVideoHumanTime(timeEntryElement.value);
+			if (imageTime === null) {
+				imageElement.classList.add("hidden");
+				addError("Couldn't preview thumbnail; couldn't parse thumbnail frame timestamp");
+				return;
+			}
+			const imageTemplate = document.getElementById("video-info-thumbnail-template").value;
+			imageElement.src = `/thumbnail/${globalStreamName}/source.png?timestamp=${imageTime}&template=${imageTemplate}`;
+			imageElement.classList.remove("hidden");
+		});
+
 	const thumbnailTemplateSelection = document.getElementById("video-info-thumbnail-template");
 	const thumbnailTemplatesListResponse = await fetch("/files/thumbnail_templates");
 	if (thumbnailTemplatesListResponse.ok) {

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -313,6 +313,10 @@ a,
 	flex-grow: 1;
 }
 
+.video-info-thumbnail-mode-options {
+	margin: 2px 0;
+}
+
 #video-info-thumbnail-template-preview-image {
 	max-width: 320px;
 }

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -313,6 +313,10 @@ a,
 	flex-grow: 1;
 }
 
+#video-info-thumbnail-template-preview-image {
+	max-width: 320px;
+}
+
 .submission-response-error {
 	white-space: pre-wrap;
 }

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -178,9 +178,9 @@ def get_row(ident):
 	]
 	if response['event_start'] is not None:
 		start = response['event_start']
-		if response['thumbnail_template'] is None:
+		if 'thumbnail_template' not in response or response['thumbnail_template'] is None:
 			response['thumbnail_template'] = DEFAULT_TEMPLATES[int(start.hour / 6)]
-		if response['thumbnail_time'] is None:
+		if 'thumbnail_time' not in response or response['thumbnail_time'] is None:
 			if response['event_end'] is not None:
 				# take full duration, and add half to start to get halfway
 				duration = response['event_end'] - start

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -178,11 +178,11 @@ def get_row(ident):
 	]
 	if response['event_start'] is not None:
 		start = response['event_start']
-		if 'thumbnail_template' not in response or response['thumbnail_template'] is None:
+		if response['thumbnail_template'] is None:
 			pst_hour = (start.hour - 8) % 24
 			shift = int(pst_hour / 6)
 			response['thumbnail_template'] = DEFAULT_TEMPLATES[shift]
-		if 'thumbnail_time' not in response or response['thumbnail_time'] is None:
+		if response['thumbnail_time'] is None:
 			if response['event_end'] is not None:
 				# take full duration, and add half to start to get halfway
 				duration = response['event_end'] - start


### PR DESCRIPTION
Adds Thrimbletrimmer support for all the new thumbnails fanciness. (This PR builds on #297 and therefore merges into that branch.)

This includes all the front-end UI for various useful tasks:
- Selecting the thumbnail type
- Choosing options based on which thumbnail type is specified
- Previewing the template (for the other three, we assume you know exactly what the thumbnail will look like or, for NONE, don't care)

Notable issues:
- Currently, custom thumbnails can't be uploaded. This seems to be a problem with thrimshim, but I'm not sure what it is. (It seems to fail on `b64decode`, which my install of Python does not for the same file/data, and it further fails trying to catch the error raised, so more useful information isn't shown to me.) I expect this should be resolved as part of #297 before it merges, but if there's secretly something I'm able to do about it, I'll give it another poke.