### PR TITLE
Add links to playlists in video descriptions

### DIFF
--- a/postgres/setup.sh
+++ b/postgres/setup.sh
@@ -144,8 +144,10 @@ CREATE TABLE editors (
 -- Playlists are communicated to playlist manager via this table.
 -- Sheetsync will wipe and re-populate this table periodically to match what is in the sheet
 CREATE TABLE playlists (
+	playlist_id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
 	tags TEXT[] NOT NULL,
-	playlist_id TEXT PRIMARY KEY
+	show_in_description BOOLEAN NOT NULL
 );
 EOSQL
 

--- a/sheetsync/sheetsync/main.py
+++ b/sheetsync/sheetsync/main.py
@@ -364,6 +364,11 @@ class SheetSync(object):
 		overwriting the entire playlists table"""
 		playlists = []
 		for row in rows:
+			# TODO redo sheet parsing for new columns
+			# Defaults for now:
+			name = ""
+			show_in_description = false
+
 			if len(row) != 3:
 				continue
 			tags, _, playlist_id = row
@@ -373,7 +378,7 @@ class SheetSync(object):
 			playlist_id = playlist_id.strip()
 			if len(playlist_id) != 34 or not playlist_id.startswith('PL'):
 				continue
-			playlists.append((tags, playlist_id))
+			playlists.append((playlist_id, tags, name, show_in_description))
 		# We want to wipe and replace all the current entries in the table.
 		# The easiest way to do this is a DELETE then an INSERT, all within a transaction.
 		# The "with" block will perform everything under it within a transaction, rolling back
@@ -381,7 +386,7 @@ class SheetSync(object):
 		logging.info("Updating playlists table with {} playlists".format(len(playlists)))
 		with self.conn:
 			query(self.conn, "DELETE FROM playlists")
-			execute_values(self.conn.cursor(), "INSERT INTO playlists(tags, playlist_id) VALUES %s", playlists)
+			execute_values(self.conn.cursor(), "INSERT INTO playlists(playlist_id, tags, name, show_in_description) VALUES %s", playlists)
 
 
 @argh.arg('dbconnect', help=

--- a/sheetsync/sheetsync/main.py
+++ b/sheetsync/sheetsync/main.py
@@ -364,20 +364,16 @@ class SheetSync(object):
 		overwriting the entire playlists table"""
 		playlists = []
 		for row in rows:
-			# TODO redo sheet parsing for new columns
-			# Defaults for now:
-			name = ""
-			show_in_description = false
-
-			if len(row) != 3:
+			if len(row) != 5:
 				continue
-			tags, _, playlist_id = row
+			tags, _, name, playlist_id, show_in_desctiption = row
 			tags = self.column_parsers['tags'](tags)
 			if not tags:
 				continue
 			playlist_id = playlist_id.strip()
 			if len(playlist_id) != 34 or not playlist_id.startswith('PL'):
 				continue
+			show_in_description = show_in_description == "[✓]"
 			playlists.append((playlist_id, tags, name, show_in_description))
 		# We want to wipe and replace all the current entries in the table.
 		# The easiest way to do this is a DELETE then an INSERT, all within a transaction.

--- a/sheetsync/sheetsync/main.py
+++ b/sheetsync/sheetsync/main.py
@@ -366,7 +366,7 @@ class SheetSync(object):
 		for row in rows:
 			if len(row) != 5:
 				continue
-			tags, _, name, playlist_id, show_in_desctiption = row
+			tags, _, name, playlist_id, show_in_description = row
 			tags = self.column_parsers['tags'](tags)
 			if not tags:
 				continue

--- a/thrimshim/thrimshim/main.py
+++ b/thrimshim/thrimshim/main.py
@@ -194,6 +194,7 @@ def get_row(ident):
 				response['thumbnail_time'] = start
 
 	# remove any added headers or footers so round-tripping is a no-op
+	# TODO make work with playlist links in description
 	if (
 		app.title_header
 		and response["video_title"] is not None


### PR DESCRIPTION
For each video, we determine the set of playlists it should be in
and add a link to each one in the video description.

This applies when we update the row via thrimshim, so if a video's tags change
its description will not be updated until the video is modified in the editor.

To faciliate this we add two new columns to the tags sheet: a name, and whether or not
it should show in the description (eg. we don't want this for the All Everything playlist).

The description footer now looks like this:
```
This video is part of the following playlists:
- Hamfather [https://youtube.com/playlist?list=PL123456]
- Something Else [https://youtube.com/playlist?list=PLdeadbeef]
Uploaded by the Desert Bus Video Strike Team