### PR TITLE
Show raids (and subscriptions and whatnot) in chat replay

### DIFF
--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -677,11 +677,13 @@ function addChatMessageTextToElement(chatMessageData, messageTextElement) {
 
 			const emoteImg = document.createElement("img");
 			emoteImg.src = `https://static-cdn.jtvnw.net/emoticons/v2/${emoteData.emote}/default/dark/1.0`;
-			emoteImg.classList.add("chat-replay-message-emote");
 			const emoteText = text.substring(emoteData.start, emoteData.end + 1);
 			emoteImg.alt = emoteText;
 			emoteImg.title = emoteText;
-			textAndEmote.push(emoteImg);
+			const emoteContainer = document.createElement("span");
+			emoteContainer.classList.add("chat-replay-message-emote");
+			emoteContainer.appendChild(emoteImg);
+			textAndEmote.push(emoteContainer);
 
 			const remainingText = text.substring(emoteData.end + 1);
 			if (remainingText !== "") {

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -1591,6 +1591,11 @@ function renderChatLog() {
 					childNode.classList.add("chat-replay-message-cleared");
 				}
 			}
+		} else if (chatMessage.message.command === "USERNOTICE") {
+			const chatDOMList = renderSystemMessages(chatMessage);
+			for (const chatDOM of chatDOMList) {
+				chatReplayParent.appendChild(chatDOM);
+			}
 		}
 	}
 }

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -296,6 +296,10 @@ function updateChatRender() {
 			lastChatIndex = Math.floor((rangeMin + rangeMax) / 2);
 		}
 
+		if (lastChatIndex === 0 && globalChatData[0].when > lastAddedTime) {
+			lastChatIndex = -1;
+		}
+
 		for (let chatIndex = lastChatIndex + 1; chatIndex < globalChatData.length; chatIndex++) {
 			const chatMessage = globalChatData[chatIndex];
 			if (chatMessage.when > videoDateTime) {

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -329,5 +329,10 @@ function handleChatMessage(chatReplayContainer, chatMessage) {
 				messageElem.classList.add("chat-replay-message-cleared");
 			}
 		}
+	} else if (chatMessage.message.command === "USERNOTICE") {
+		const chatDOMList = renderSystemMessages(chatMessage);
+		for (const chatDOM of chatDOMList) {
+			chatReplayContainer.appendChild(chatDOM);
+		}
 	}
 }

--- a/thrimbletrimmer/styles/thrimbletrimmer.css
+++ b/thrimbletrimmer/styles/thrimbletrimmer.css
@@ -392,6 +392,10 @@ a,
 	font-style: italic;
 }
 
+.chat-replay-message-system {
+	color: #aaf;
+}
+
 .chat-replay-message-text-action .chat-replay-message-reply:not(.chat-replay-message-text-action) {
 	font-style: normal; /* Clear the italics from the action */
 }


### PR DESCRIPTION
I added support for the USERNOTICE command, as mentioned before (in the previous chat PR). This adds support for raid notices. Although we don't need it for Desert Bus, it also supports subscription messages, and I tested it with a variety of subscription messages (new subscriptions, resubs, resubs with messages, resubs with messages that contain emotes).

I chose to continue not adding highlights to first messages from a given user (which Twitch chat highlights with a green background). If we think this highlighting would be useful, let me know, and I can add it in a future enhancement.

While I was in here, I also fixed a couple bugs that came up in my testing:
- Some of the default Twitch emotes are a non-standard size (not 28x28), so I added a fix to prevent distorting those emotes (while still reserving the 28x28 size, which was necessary to prevent breaking the chat scroll when emotes needed to be fetched from Twitch rather than loaded from the cache).
- I also noticed that the first message in restreamer gets skipped, so I added a fix for that to my "find the last processed message" search.