### PR TITLE
Don't show a template option for non-png files

### DIFF
--- a/restreamer/restreamer/main.py
+++ b/restreamer/restreamer/main.py
@@ -155,6 +155,20 @@ def list_segments(channel, quality, hour):
 	return json.dumps(list_segment_files(path, include_tombstones=tombstones))
 
 
+@app.route('/thumbnail-templates')
+def list_thumbnail_templates():
+	"""List available thumbnail templates. Returns a JSON list of names."""
+	path = os.path.join(
+		app.static_folder,
+		"thumbnail_templates",
+	)
+	return json.dumps([
+		os.path.splitext(filename)[0]
+		for filename in listdir(path)
+		if os.path.splitext(filename)[1] == ".png"
+	])
+
+
 def time_range_for_quality(channel, quality):
 	"""Returns earliest and latest times that the given quality has segments for
 	(up to hour resolution), or 404 if it doesn't exist / is empty."""

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -253,13 +253,11 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 		});
 
 	const thumbnailTemplateSelection = document.getElementById("video-info-thumbnail-template");
-	const thumbnailTemplatesListResponse = await fetch("/files/thumbnail_templates");
+	const thumbnailTemplatesListResponse = await fetch("/thumbnail-templates");
 	if (thumbnailTemplatesListResponse.ok) {
 		const thumbnailTemplatesList = await thumbnailTemplatesListResponse.json();
-		for (const templateFileName of thumbnailTemplatesList) {
+		for (const templateName of thumbnailTemplatesList) {
 			const templateOption = document.createElement("option");
-			// Thumbnails are fetched from restreamer with file extensions. The thumbnail name is the file name.
-			const templateName = templateFileName.substring(0, templateFileName.lastIndexOf("."));
 			templateOption.innerText = templateName;
 			templateOption.value = templateName;
 			if (templateName === videoInfo.thumbnail_template) {


### PR DESCRIPTION
Each template now has two files, a `.png` and a `.json`. This is currently making them show up twice.
To fix this, we only consider files which end in `.png`.