### PR TITLE
chat_archiver: Download each seen emote

### DIFF
--- a/chat_archiver/setup.py
+++ b/chat_archiver/setup.py
@@ -11,5 +11,6 @@ setup(
 		'argh',
 		'gevent',
 		'monotonic',
+		'requests', # for emote fetching
 	],
 )


### PR DESCRIPTION
so we have a permanent record, in case they're deleted or changed later.

We'll continue to use twitch's copy in thrimbletrimmer as it will be faster (CDN).