### PR TITLE
Thrimbletrimmer chat performance & updates

### DIFF
--- a/thrimbletrimmer/edit.html
+++ b/thrimbletrimmer/edit.html
@@ -8,6 +8,7 @@
 
 		<script src="scripts/hls.min.js"></script>
 		<script src="scripts/luxon.min.js"></script>
+		<script src="scripts/common-worker.js"></script>
 		<script src="scripts/common.js"></script>
 		<script src="scripts/edit.js"></script>
 		<script src="scripts/keyboard-shortcuts.js"></script>

--- a/thrimbletrimmer/index.html
+++ b/thrimbletrimmer/index.html
@@ -8,6 +8,7 @@
 
 		<script src="scripts/hls.min.js"></script>
 		<script src="scripts/luxon.min.js"></script>
+		<script src="scripts/common-worker.js"></script>
 		<script src="scripts/common.js"></script>
 		<script src="scripts/stream.js"></script>
 		<script src="scripts/keyboard-shortcuts.js"></script>

--- a/thrimbletrimmer/scripts/chat-load.js
+++ b/thrimbletrimmer/scripts/chat-load.js
@@ -1,0 +1,49 @@
+self.importScripts("luxon.min.js", "common-worker.js");
+
+var DateTime = luxon.DateTime;
+luxon.Settings.defaultZone = "utc";
+
+self.onmessage = async (event) => {
+	const chatLoadData = event.data;
+
+	const segmentMetadata = chatLoadData.segmentMetadata;
+	for (const segmentData of segmentMetadata) {
+		segmentData.rawStart = DateTime.fromMillis(segmentData.rawStart);
+		segmentData.rawEnd = DateTime.fromMillis(segmentData.rawEnd);
+	}
+
+	const fetchURL = `/${chatLoadData.stream}/chat.json?start=${chatLoadData.start}&end=${chatLoadData.end}`;
+	const chatResponse = await fetch(fetchURL);
+	if (!chatResponse.ok) {
+		return;
+	}
+	const chatRawData = await chatResponse.json();
+
+	const chatData = [];
+	for (const chatLine of chatRawData) {
+		if (
+			chatLine.command !== "PRIVMSG" &&
+			chatLine.command !== "CLEARMSG" &&
+			chatLine.command !== "CLEARCHAT" &&
+			chatLine.command !== "USERNOTICE"
+		) {
+			continue;
+		}
+		const when = DateTime.fromSeconds(chatLine.time);
+		const displayWhen = videoHumanTimeFromDateTimeWithFragments(segmentMetadata, when);
+		// Here, we just push each line successively into the list. This assumes data is provided to us in chronological order.
+		chatData.push({ message: chatLine, when: when.toMillis(), displayWhen: displayWhen });
+	}
+	self.postMessage(chatData);
+};
+
+function videoHumanTimeFromDateTimeWithFragments(fragmentMetadata, dateTime) {
+	for (const segmentData of fragmentMetadata) {
+		if (dateTime >= segmentData.rawStart && dateTime <= segmentData.rawEnd) {
+			const playerTime =
+				segmentData.playerStart + dateTime.diff(segmentData.rawStart).as("seconds");
+			return videoHumanTimeFromVideoPlayerTime(playerTime);
+		}
+	}
+	return null;
+}

--- a/thrimbletrimmer/scripts/common-worker.js
+++ b/thrimbletrimmer/scripts/common-worker.js
@@ -1,0 +1,21 @@
+function videoHumanTimeFromVideoPlayerTime(videoPlayerTime) {
+	const hours = Math.floor(videoPlayerTime / 3600);
+	let minutes = Math.floor((videoPlayerTime % 3600) / 60);
+	let seconds = Math.floor(videoPlayerTime % 60);
+	let milliseconds = Math.floor((videoPlayerTime * 1000) % 1000);
+
+	while (minutes.toString().length < 2) {
+		minutes = `0${minutes}`;
+	}
+	while (seconds.toString().length < 2) {
+		seconds = `0${seconds}`;
+	}
+	while (milliseconds.toString().length < 3) {
+		milliseconds = `0${milliseconds}`;
+	}
+
+	if (hours > 0) {
+		return `${hours}:${minutes}:${seconds}.${milliseconds}`;
+	}
+	return `${minutes}:${seconds}.${milliseconds}`;
+}

--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -604,7 +604,11 @@ function renderSystemMessages(chatMessageData) {
 	const systemTextElement = document.createElement("div");
 	systemTextElement.classList.add("chat-replay-message-text");
 	systemTextElement.classList.add("chat-replay-message-system");
-	systemTextElement.appendChild(document.createTextNode(chatMessage.tags["system-msg"]));
+	let systemMsg = chatMessage.tags["system-msg"];
+	if (!systemMsg && chatMessage.tags["msg-id"] === "announcement") {
+		systemMsg = "Announcement";
+	}
+	systemTextElement.appendChild(document.createTextNode(systemMsg));
 
 	const firstMessageContainer = createMessageContainer(chatMessageData, true);
 	firstMessageContainer.appendChild(sendTimeElement);

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -7,6 +7,10 @@ const CHAPTER_MARKER_DELIMITER_PARTIAL = "==========";
 
 window.addEventListener("DOMContentLoaded", async (event) => {
 	commonPageSetup();
+	globalLoadChatWorker.onmessage = (event) => {
+		updateChatDataFromWorkerResponse(event.data);
+		renderChatLog();
+	};
 
 	const timeUpdateForm = document.getElementById("stream-time-settings");
 	timeUpdateForm.addEventListener("submit", async (event) => {
@@ -338,20 +342,6 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 	document.getElementById("google-auth-sign-out").addEventListener("click", (_event) => {
 		googleSignOut();
 	});
-
-	await loadEditorChatData();
-	if (globalChatData) {
-		if (hasSegmentList()) {
-			renderChatLog();
-		} else {
-			const videoPlayer = document.getElementById("video");
-			const initialChatLogRender = (_event) => {
-				renderChatLog();
-				videoPlayer.removeEventListener("loadedmetadata", initialChatLogRender);
-			};
-			videoPlayer.addEventListener("loadedmetadata", initialChatLogRender);
-		}
-	}
 });
 
 async function loadVideoInfo() {
@@ -1540,10 +1530,6 @@ async function rangeDataUpdated() {
 		}
 	}
 	updateDownloadLink();
-
-	await getChatLog(globalStartTimeString, globalEndTimeString);
-	document.getElementById("chat-replay").innerHTML = "";
-	renderChatLog();
 }
 
 function setCurrentRangeStartToVideoTime() {
@@ -1589,13 +1575,6 @@ function changeEnableChaptersHandler() {
 			addChapterMarkerElem.classList.add("hidden");
 		}
 	}
-}
-
-async function loadEditorChatData() {
-	if (!globalStartTimeString || !globalEndTimeString) {
-		return [];
-	}
-	return getChatLog(globalStartTimeString, globalEndTimeString);
 }
 
 function renderChatLog() {

--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -1593,9 +1593,16 @@ function renderChatLog() {
 				removedMessageElem.classList.add("chat-replay-message-cleared");
 			}
 		} else if (chatMessage.message.command === "CLEARCHAT") {
-			const removedSender = chatMessage.message.params[1];
-			for (const childNode of document.getElementById("chat-replay").children) {
-				if (childNode.dataset.sender === removedSender) {
+			if (chatMessage.message.params.length > 1) {
+				const removedSender = chatMessage.message.params[1];
+				for (const childNode of document.getElementById("chat-replay").children) {
+					if (childNode.dataset.sender === removedSender) {
+						childNode.classList.add("chat-replay-message-cleared");
+					}
+				}
+			} else {
+				// Without a target parameter, the CLEARCHAT clears all messages in the entire chat.
+				for (const childNode of document.getElementById("chat-replay").children) {
 					childNode.classList.add("chat-replay-message-cleared");
 				}
 			}

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -320,9 +320,15 @@ function handleChatMessage(chatReplayContainer, chatMessage) {
 			targetMessageElem.classList.add("chat-replay-message-cleared");
 		}
 	} else if (chatMessage.message.command === "CLEARCHAT") {
-		const removedSender = chatMessage.message.params[1];
-		for (const messageElem of chatReplayContainer.children) {
-			if (messageElem.dataset.sender === removedSender) {
+		if (chatMessage.message.params.length > 1) {
+			const removedSender = chatMessage.message.params[1];
+			for (const messageElem of chatReplayContainer.children) {
+				if (messageElem.dataset.sender === removedSender) {
+					messageElem.classList.add("chat-replay-message-cleared");
+				}
+			}
+		} else {
+			for (const messageElem of chatReplayContainer.children) {
 				messageElem.classList.add("chat-replay-message-cleared");
 			}
 		}

--- a/thrimbletrimmer/scripts/stream.js
+++ b/thrimbletrimmer/scripts/stream.js
@@ -8,6 +8,10 @@ var globalChatPreviousRenderTime = null;
 
 window.addEventListener("DOMContentLoaded", async (event) => {
 	commonPageSetup();
+	globalLoadChatWorker.onmessage = (event) => {
+		updateChatDataFromWorkerResponse(event.data);
+		initialChatRender();
+	};
 
 	const queryParams = new URLSearchParams(window.location.search);
 	if (queryParams.has("start")) {
@@ -124,8 +128,6 @@ async function updateTimeSettings() {
 		queryParts.push(`end=${wubloaderTimeFromDateTime(endTime)}`);
 	}
 	document.getElementById("stream-time-link").href = `?${queryParts.join("&")}`;
-
-	await getStreamChatLog();
 }
 
 function generateDownloadURL(startTime, endTime, downloadType, allowHoles, quality) {
@@ -230,15 +232,6 @@ function convertEnteredTimes() {
 	}
 }
 
-async function getStreamChatLog() {
-	const startTime = getStartTime();
-	const endTime = getEndTime();
-	if (!startTime || !endTime) {
-		return;
-	}
-	return getChatLog(wubloaderTimeFromDateTime(startTime), wubloaderTimeFromDateTime(endTime));
-}
-
 function initialChatRender() {
 	if (!globalChatData || globalChatData.length === 0) {
 		return;
@@ -261,7 +254,7 @@ function initialChatRender() {
 }
 
 function updateChatRender() {
-	if (!globalChatData || globalChatData === 0) {
+	if (!globalChatData || globalChatData.length === 0) {
 		return;
 	}
 	if (!hasSegmentList()) {


### PR DESCRIPTION
This does a few things.

The thing I think will be most problematic that this fixes is the performance of chat updates in the restreamer. It turned out that, when seeking, the cost of calculating the video human time for each line of chat being rendered on screen was too high, causing the video to hang for several seconds while the chat code figured out all of the displayable timestamps. This calculation now occurs once on load in the background instead, so it's calculated for all messages before any chat data is displayed, and it does so without hanging the initial video load (nor, as before, does it cause the seek to hang). I expect this would've been a much bigger problem for restreamer than for the editor (which shows a static chat display that needs determined once on load and doesn't get updated/rerendered) but the cost was bad enough that I applied it to both. It likely would've taken a long time to load the editor for large videos otherwise.

I also made two other fixes, which I unfortunately couldn't really test (due to occurring outside of the stream being online):
- Clearing the whole chat, which I'm reasonably confident works
- Announcements, for which I expect we'll want to tweak the UI a bit (right now it works like all the other USERNOTICEs with "Announcement" in place of whatever system message was there before).