### PR TITLE
Prevent cut modifications when a video that was already uploaded is being modified

### DIFF
--- a/thrimbletrimmer/scripts/edit.js
+++ b/thrimbletrimmer/scripts/edit.js
@@ -151,14 +151,16 @@ window.addEventListener("DOMContentLoaded", async (event) => {
 	});
 
 	const addRangeIcon = document.getElementById("add-range-definition");
-	addRangeIcon.addEventListener("click", (_event) => {
-		addRangeDefinition();
-	});
-	addRangeIcon.addEventListener("keypress", (event) => {
-		if (event.key === "Enter") {
+	if (videoInfo.state !== "DONE") {
+		addRangeIcon.addEventListener("click", (_event) => {
 			addRangeDefinition();
-		}
-	});
+		});
+		addRangeIcon.addEventListener("keypress", (event) => {
+			if (event.key === "Enter") {
+				addRangeDefinition();
+			}
+		});
+	}
 
 	const enableChaptersElem = document.getElementById("enable-chapter-markers");
 	enableChaptersElem.addEventListener("change", (_event) => {
@@ -494,6 +496,16 @@ async function initializeVideoInfo() {
 		saveButton.classList.add("hidden");
 		const submitChangesButton = document.getElementById("submit-changes-button");
 		submitChangesButton.classList.remove("hidden");
+
+		document.getElementById("add-range-definition").classList.add("hidden");
+		const startTimes = document.getElementsByClassName("range-definition-start");
+		const endTimes = document.getElementsByClassName("range-definition-end");
+		for (const timeField of startTimes) {
+			timeField.disabled = true;
+		}
+		for (const timeField of endTimes) {
+			timeField.disabled = true;
+		}
 	}
 
 	if (modifiedAdvancedOptions) {


### PR DESCRIPTION
This isn't a particularly high-priority fix, especially since we were smart enough to handle these on the server side anyway. I think the client-side changes will make it clearer what can be done to an edited video.