### PR TITLE
Fix loading chat for non-UTC timestamps in restreamer

### DIFF
--- a/thrimbletrimmer/scripts/common.js
+++ b/thrimbletrimmer/scripts/common.js
@@ -516,11 +516,13 @@ function triggerDownload(url, filename) {
 }
 
 function sendChatLogLoadData() {
-	const startTime = globalStartTimeString;
-	const endTime = globalEndTimeString;
+	let startTime = getStartTime();
+	let endTime = getEndTime();
 	if (!startTime || !endTime) {
 		return;
 	}
+	startTime = wubloaderTimeFromDateTime(startTime);
+	endTime = wubloaderTimeFromDateTime(endTime);
 	const segmentMetadata = getSegmentTimes();
 	for (const segmentData of segmentMetadata) {
 		segmentData.rawStart = segmentData.rawStart.toMillis();


### PR DESCRIPTION
Somehow missed this the whole run. I wrote something in common.js as if it were edit.js, which is not correct.